### PR TITLE
Proposed Cleanup, Optimizations & Prep for Multi-controller

### DIFF
--- a/apps/Spruce Connect.src
+++ b/apps/Spruce Connect.src
@@ -29,7 +29,16 @@
  * v1.3bab - Create more descriptive device.labels for Controller, Zones and Spruce Pause devices
  *         - (NOTE: Spruce wifi master now uses the Pause device.deviceNetworkId instead of device.name)
  * v1.4bab - Added debug on/off, cleaned up settings collection pages
- * v.15bab - Handle sensor device rename
+ * v1.5bab - Handle sensor device rename
+ *		   - (NOTE: Sensor names are defined by Hubitat devices - Spruce Cloud App edits will be overwritten)
+ * v1.6bab - Enable instances (not currently supported by Spruce Cloud), with custom label names
+ * v1.7bab - Create/Rename all controllers, zones and schedules when installed AND when updated
+ *		   - Don't delete existing children - rename them if name or label changes in the Spruce Cloud
+ *		   - (NOTE: Contyroller, Zone & Schedule names are defined by the Spruce Cloud App - local edits will be overwritten)
+ *		   - Refresh sensors 30 seconds after initialization (resend all states to Spruce Cloud)
+ *		   - Add 30-second timeout to all http calls
+ *		   - Remove Pause device if not configured
+ *		   - Remove unused/deleted zones & schedules after creating/renaming the current ones
  *
  */
 
@@ -45,7 +54,7 @@ definition(
     oauth: true,
     singleInstance: true
 )
-String getVersionText()     {return "Spruce-Connect v1.5bab\nRelease: 05.2020"}
+String getVersionText()     {return "Spruce Connect v1.7bab\nRelease: 06.02.2020"}
 String getClientId()        {return "hubitat"}
 String getClientSecret()    {return "6137b7f5efabd2f8a82f80c95f6dd50807426f72"}
 
@@ -60,7 +69,6 @@ preferences (oauthPage: "authPage") {
 
 def authPage(){
 
-    
     if(!atomicState.accessToken) atomicState.accessToken = createAccessToken()	//set = so token is saved to atomicState 
     
     if(!atomicState.authToken){
@@ -114,7 +122,9 @@ def pageDevices(){
       log.debug "pageDevices"
         dynamicPage(name: "pageDevices", title:"<h3><b>${getVersionText()}</b></h3>", uninstall: true, install:true) {
         	if(atomicState.zoneUpdate == true) section("<b>Device changes found, device tiles will be updated!</b>\n\nDevice tiles and automations must be updated!\n"){}
-            section("<b>Settings for Connected devices\nConnected controller:</b> ${settings.controller}\n<b>Connected zones:</b> ${zoneList()}") {}
+            section("<b>Settings for Connected devices\nConnected controller:</b> ${settings.controller}\n<b>Connected zones:</b> ${zoneList()}") {
+				label title: "<b>Enter a name for this instance</b>", required: false, submitOnChange: true
+			}
 			section("<b>Notifications</b>") {
                 input "sendPushMessage", "capability.notification", title: "<b>Notification Devices</b>", descriptionText: "Select Hubitat notification devices", multiple: true, required: false
                 input(name: "notifications", title:"<b>Notifications to Send</b>", type: "enum", required:false, multiple:true, description: "Select desired notifications", options: ['Schedule','Zone','Valve Fault'])                
@@ -123,7 +133,7 @@ def pageDevices(){
                 paragraph "Select local Spruce Sensors that will be reported to Spruce Cloud:"
                 input "sensors", "device.SpruceSensor", title: "<b>Spruce Moisture Sensors:</b>", required: false, multiple: true
             }
-                section("<b>Pause and resume</b>") {
+            section("<b>Pause and resume</b>") {
                 paragraph "Use the Spruce Pause control with Hubitat Rule Machine, or add contact sensors without any rules to pause & resume irrigation."
                 input(name: "pause", title:"<b>Create the Spruce Pause control</b>", type: 'bool', defaultValue: false)
             	input "contacts", "capability.contactSensor", title: "<b>Contact Sensors</b>", descriptionText: "Select contact sensors that will pause watering when open", required: false, multiple: true
@@ -210,29 +220,32 @@ def updated() {
 }
 
 def initialize() {	
-    log.debug "initialize"
-	if (infoOn) log.info "${linkText} info logging enabled"
-	if (debugOn) log.info "${linkText} debug logging enabled for 30 minutes"
+    log.debug "${app.label} - Initializing..."
+	if (infoOn) log.info "${app.label} - info logging enabled"
+	if (debugOn) log.debug "${app.label} - debug logging enabled for 30 minutes"
 	atomicState.versionText = getVersionText()
 	atomicState.clientId = getClientId()
 	atomicState.clientSecret = getClientSecret()
 	
     atomicState.zones_on = 0
     
-    if (settings.sensors) getSensors()
+	if (settings.sensors) {getSensors(); runIn(30, sensorUpdater, [overwrite: true]); }
     if (settings.contacts) getContacts()
     
     //add devices to web, check for schedules
     if(atomicState.accessToken){
-    	log.debug getApiServerUrl()
-        addDevices()
+    	if (debugOn) log.debug getApiServerUrl()
+        addDevices()					// Add/update Sensors to DB
+		atomicState.zoneUpdate = true	// Check for new or renamed zones
+		atomicState.manUpdate = true	// Check for new of renamed manual schedules
     	createChildDevices()        
 	}  
+	
     if (debugOn) runIn(1800, debugOff, [overwrite: true])
 }
 
 def debugOff(){
-    log.debug "debug logging disabled..."
+    log.debug "${app.label} - debug logging disabled..."
     app.updateSetting("debugOn",[value:"false",type:"bool"])
     settings.debugOn = false
 }
@@ -287,34 +300,83 @@ def getContacts(){
 private void createChildDevices(){
 	if (debugOn) log.debug "create zone children ${atomicState.zoneUpdate} with ${app.id}"
     if(atomicState.zoneUpdate == true){
-    	removeChildDevices()
+    	//removeChildDevices()
     
         //set Spruce Controller Name  
 		String controllerName = settings.controller
 		if (!controllerName.contains("Spruce")) controllerName = "Spruce " + controllerName
 		if (!controllerName.contains("Controller")) controllerName = controllerName + " Controller"
-        addChildDevice("plaidsystems", "Spruce wifi master", "${app.id}.0", null, [completedSetup: true, label: "${controllerName}", isComponent: false, name: "Spruce WiFi Controller"])
+		def existingChild = getChildDevice("${app.id}.0") // childDevices?.find(it.value.deviceNetworkId == "${app.id}.0")	// The controller
+		String name = "Spruce WiFi Controller"
+		if (!existingChild) {
+			if (infoOn) log.info "${app.label} - Creating Controller: ${controllerName} / ${name} (${app.id}0)"
+        	addChildDevice("plaidsystems", "Spruce wifi master", "${app.id}.0", null, [completedSetup: true, label: "${controllerName}", isComponent: false, name: name])
+		} else {
+			boolean renamed = false
+			if (existingChild.name != name) {
+				existingChild.name = name
+				renamed = true
+			}
+			if (existingChild.label != controllerName) {
+				existingChild.label = controllerName
+				renamed = true
+			}
+			if (renamed) {
+				if (infoOn) log.info "${app.label} - Renamed Controller ${controllerName} / ${name} (${app.id}.0)"
+			} else {
+				if (infoOn) log.info "${app.label} - Controller ${controllerName} / ${name} (${app.id}.0) already exists"
+			}
+		}
 
         //Create children
 		String prefix = controllerName.endsWith(' Controller') ? controllerName - " Controller" : controllerName
         def tempZoneMap = atomicState.zoneMap
         tempZoneMap.each{
 			String label = "${prefix} ${it.key} - ${tempZoneMap[it.key]['zone_name']}"
-			String name = "${controllerName} Zone ${it.key}"
-            addChildDevice("plaidsystems", "Spruce wifi zone", "${app.id}.${it.key}", null, [completedSetup: true, label: label, isComponent: false, name: name])
+			name = "${controllerName} Zone ${it.key}"
+			String childDNI = "${app.id}.${it.key}"
+			existingChild = getChildDevice(childDNI) //getChildDevices().find(it.deviceNetworkId == childDNI)
+			if (!existingChild) {
+				if (infoOn) log.info "${app.label} - Adding Spruce wifi zone: ${label} / ${name} (${childDNI})"
+				addChildDevice("plaidsystems", "Spruce wifi zone", childDNI, null, [completedSetup: true, label: label, isComponent: false, name: name])
+			} else {
+				boolean renamed = false
+				if (existingChild.name != name) {
+					existingChild.name = name
+					renamed = true
+				}
+				if (existingChild.label != label) {
+					existingChild.label = label
+					renamed = true
+				}
+				if (renamed) {
+					if (infoOn) log.info "${app.label} - Renamed Spruce wifi zone ${label} / ${name} (${childDNI})"
+				} else {
+					if (infoOn) log.info "${app.label} - Spruce wifi zone ${label} / ${name} (${childDNI}) already exists"
+				}
+			}
         }
+		//remove any unused child zones
+		childDevices?.each() {
+			if (it.typeName == "Spruce wifi zone") {
+				def index = it.deviceNetworkId.toString().tokenize('.').last()
+				if (!tempZoneMap || !tempZoneMap[index]) {
+					if (infoOn) log.info "${app.label} - Removing unused Spruce wifi zone ${it.label} / ${it.name} (${it.deviceNetworkId})"
+					deleteChildDevice(it.deviceNetworkId)
+				}
+			}
+		}
     }
-    if (atomicState.manUpdate == true) child_schedules("${app.id}.0")
-        
+    if (atomicState.manUpdate == true) child_schedules("${app.id}.0")      
 }
 
-//remove zone tiles children
+//remove zone tiles children - SHOULD ONLY BE CALLED WHEN REMOVING THIS INSTANCE!!!
 private removeChildDevices() {
-	if (debugOn) log.debug "remove children"
+	if (debugOn) log.debug "remove ALL children"
 	
     //get and delete children avoids duplicate children
     def children = getChildDevices()  
-    if (debugOn) log.debug children
+	if (debugOn) log.debug "removing ${children}"
     if(children != null){
         children.each{
         	deleteChildDevice(it.deviceNetworkId)
@@ -325,27 +387,55 @@ private removeChildDevices() {
 //add child device tiles to master
 def child_schedules(dni){
 	if (debugOn) log.debug "get child tiles for master"
-	def childDevice = childDevices.find{it.deviceNetworkId == dni}
+	def childDevice = getChildDevice(dni) 	// childDevices.find{it.deviceNetworkId == dni}
     if (debugOn) log.debug "${childDevice}"
     
+	String controllerName = settings.controller
+	if (!controllerName.startsWith("Spruce ")) controllerName = "Spruce " + controllerName
+	if (!controllerName.endsWith(" Controller")) controllerName = controllerName + " Controller"
+	
     // Pause Device for this Controller
 	if(settings.pause == true) {
-		String controllerName = settings.controller
-		if (!controllerName.startsWith("Spruce ")) controllerName = "Spruce " + controllerName
-		if (!controllerName.endsWith(" Controller")) controllerName = controllerName + " Controller"
-		childDevice.createScheduleDevices("${app.id}", 99, 0, "${controllerName} Pause")
+		if (!childDevice.getChildDevice("${app.id}.99")) {
+			childDevice.createScheduleDevices("${app.id}", 99, 0, "${controllerName} Pause")
+			if (infoOn) log.info "${app.label} - Added ${controllerName} Pause device (${app.id}.99)"
+		} else {
+			if (infoOn) log.info "${app.label} - ${controllerName} Pause device (${app.id}.99) already exists"
+		}
+	} else {
+		if (childDevice.getChildDevice("${app.id}.99")) {
+			if (infoOn) log.info "${app.label} - Removing ${controllerName} Pause device (${app.id}.99)"
+			childDevice.removeScheduleDevice("${app.id}", 99)
+		}
 	}
     
     //add manual schedules
-    def manualschs = atomicState.manualMap    
-    manualschs.each{        
-    	childDevice.createScheduleDevices("${app.id}", it.key, manualschs[it.key]["scheduleid"], manualschs[it.key]["name"])        
+    def manualschs = atomicState.manualMap   
+    manualschs?.each{        
+    	childDevice.createScheduleDevices("${app.id}", it.key, manualschs[it.key]["scheduleid"], manualschs[it.key]["name"])
+		if (infoOn) log.info "${app.label} - Added ${manualschs[it.key]["name"]} Schedule device (${app.id}.${it.key})"
     }
+	
+	//and then remove any manual schedules that are no longer enabled
+	if (!manualschs && (settings.pause == false)) {
+		if (infoOn) log.info "${app.label} - Removing all children of ${childDevice}"
+		childDevice.removeScheduleDevices()	// remove all the Controller's children
+	} else {
+		childDevice.getChildDevices()?.each {
+			if (it.deviceNetworkId != "${app.id}.99") {		// Pause device should have already been deleted above...
+				def index = it.deviceNetworkId.toString().tokenize('.').last()
+				if (!manualschs || !manualschs[index]) {
+					if (infoOn) log.info "${app.label} - Removing unused Schedule ${it.label} / ${it.name} (${it.deviceNetworkId})"
+					childDevice.removeScheduleDevice("${app.id}", index)
+				}
+			}
+		}
+	}
 }
 
 //add zone settings to child tile
 def child_zones(dni){
-	def childDevice = childDevices.find{it.deviceNetworkId == dni}
+	def childDevice = getChildDevice(dni)	// childDevices.find{it.deviceNetworkId == dni}
     if (debugOn) log.debug "${childDevice.deviceNetworkId}"
         
     def tempZoneMap = atomicState.zoneMap    
@@ -372,18 +462,19 @@ def addDevices(){
                 device_id: it.value,
                 sensor_name: it.key,                
                 gateway: "smartthings" //gateway must be labeled smartthings until a later date
-                ]
+                ],
+			timeout: 30
         ]
         //sendPost(POSTparams)
         try{
             httpPost(POSTparams) { resp -> //resp.data {
-                if (debugOn) {
-                	log.debug "Add Sensor to DB ${it.key}: ${resp?.data?.message}"
+                if (infoOn) {
+                	log.info "${app.label} - Add Sensor ${it.key} to DB: ${resp?.data?.message}"
 				}
             }                
         } 
         catch (e) {
-            log.warn "send DB error: $e"
+			log.warn "${app.label} - Add Sensor ${it.key} to DB error: $e"
         }
     }    
 
@@ -401,6 +492,7 @@ def getControllerList(){
     def GETparams = [
         uri: newuri,		
         headers: [ 	"Authorization": "Bearer ${key}"],
+		timeout: 30
     ]
 
     try{ httpGet(GETparams) { resp ->	
@@ -448,6 +540,7 @@ def getControllerSettings(){
     def GETparams = [
         uri: newuri,		
         headers: [ 	"Authorization": "Bearer ${key}"],
+		timeout: 30
     ]
 
     try{ httpGet(GETparams) { resp ->	
@@ -557,10 +650,68 @@ def getScheduleName(scheduleid){
         
 	return scheduleName
 }
-
+def sensorUpdater() {
+	if (settings.sensors) {
+		if (infoOn) log.info "${app.label} - Updating DB states for ${settings.sensors.size()} sensors"
+		if (!atomicState.sensors) {
+			def tempSensors = [:]
+			settings.sensors.each{
+				tempSensors[it] = (it.device.zigbeeId)
+			}
+			atomicState.sensors = tempSensors
+		}
+		def uri = "https://api.spruceirrigation.com/v2/"
+		settings.sensors.each{
+			def moisture = it.currentValue('humidity')
+			def temperature = it.currentValue('temperature')
+			if ( temperature && (temperatureScale == 'C')) temperature = temperature * 9/5 + 32
+			def battery = it.currentValue('battery')?.toInteger() * 5 + 2500
+			
+			if (moisture) {
+				if (infoOn) log.info "${app.label} - ${it.displayName}, moisture: ${moisture}"
+				def POSTparams = [
+					uri: uri + "moisture",
+					body: [
+						deviceid: it.device.zigbeeId,
+						value: moisture                        
+					],
+					timeout: 30
+				]
+				sendPost(POSTparams)
+			}
+			if (temperature) {
+				if (infoOn) log.info "${app.label} - ${it.displayName}, temperature: ${temperature}"
+				def POSTparams = [
+					uri: uri + "temperature",
+					body: [
+						deviceid: it.device.zigbeeId,
+						value: temperature                        
+					],
+					timeout: 30
+				]
+				sendPost(POSTparams)
+			}
+			if (battery) {
+				if (infoOn) log.info "${app.label} - ${it.displayName}, battery: ${battery}"
+				def POSTparams = [
+					uri: uri + "battery",
+					body: [
+						deviceid: it.device.zigbeeId,
+						value: battery                        
+					],
+					timeout: 30
+				]
+				sendPost(POSTparams)
+			}
+		}
+		if (infoOn) log.info "${app.label} - Sensor updates finished"
+	} else {
+		if (infoOn) log.info "${app.label} - - No sensors configured"
+	}
+}
 //sensor evts
 def sensorHandler(evt) {
-    log.info "${app.label} sensorHandler: ${evt.device}, ${evt.name}: ${evt.value}"
+    if (infoOn) log.info "${app.label} - ${evt.device.displayName}, ${evt.name}: ${evt.value}"
     
     String device = atomicState.sensors["${evt.device}"] as String
 	if (!device && settings.sensors) {
@@ -592,7 +743,8 @@ def sensorHandler(evt) {
 			body: [
 				deviceid: device,
 				value: value                        
-			]
+			],
+			timeout: 30
 		]
 
 		sendPost(POSTparams)
@@ -603,12 +755,12 @@ def sensorHandler(evt) {
 
 //contact evts
 def contactHandler(evt) {
-    log.info "${app.label} contactHandler: ${evt.device}, ${evt.name}, ${evt.value}"
+    log.info "${app.label} - contactHandler: ${evt.device}, ${evt.name}, ${evt.value}"
     
     def device = atomicState.contacts["${evt.device}"]    
     def value = evt.value
         
-    def childDevice = childDevices.find{it.deviceNetworkId == "${app.id}.0"}
+	def childDevice = getChildDevice("${app.id}.0")	// childDevices.find{it.deviceNetworkId == "${app.id}.0"}
     
     if (debugOn) log.debug "Found ${childDevice}"
     if (childDevice != null){    	
@@ -642,7 +794,7 @@ void getChildren(){
         }
     }
         
-    def childDevice = childDevices.find{it.deviceNetworkId == "${app.id}.0"}
+	def childDevice = getChildDevice("${app.id}.0")	// childDevices.find{it.deviceNetworkId == "${app.id}.0"}
     childDevice.updateChildren()
 }
 
@@ -652,7 +804,7 @@ def event(){
     def command = params.command
 	def event = command.split(',')
     
-	def masterDevice = childDevices.find{it.deviceNetworkId == "${app.id}.0"}
+	def masterDevice = getChildDevice("${app.id}.0")	// childDevices.find{it.deviceNetworkId == "${app.id}.0"}
     if (masterDevice != null){  	
         def scheduleName = getScheduleName(event[2])
         def result = [name: 'status', value: "${event[0]}", descriptionText: "${scheduleName} starting\n${event[1]}", isStateChange: true, displayed: false]
@@ -682,7 +834,7 @@ def rain(){
     def value = (zoneonoff[1].toInteger() == 1 ? 'on' : 'off')
     def message = "rain sensor is ${value}"
             
-    def masterDevice = childDevices.find{it.deviceNetworkId == "${app.id}.0"}
+    def masterDevice = getChildDevice("${app.id}.0")	// childDevices.find{it.deviceNetworkId == "${app.id}.0"}
     
     def result = [name: name, value: value, descriptionText: "${masterDevice} ${message}", isStateChange: true, displayed: true]
     if (debugOn) log.debug result
@@ -705,7 +857,7 @@ def hold(){
     def value = (zoneonoff[1].toInteger() == 1 ? 'on' : 'off')
     def message = "pause is ${value}"
             
-    def masterDevice = childDevices.find{it.deviceNetworkId == "${app.id}.0"}
+    def masterDevice = getChildDevice("${app.id}.0")	// childDevices.find{it.deviceNetworkId == "${app.id}.0"}
     
     def result = [name: name, value: value, descriptionText: "${masterDevice} ${message}", isStateChange: true, displayed: true]
     if (debugOn) log.debug result
@@ -735,8 +887,8 @@ def zone_state(){
     else if (zoneonoff[1].toInteger()<10) ks = "0${zoneonoff[1]}"
    	else ks = zoneonoff[1]
 
-    def childDevice = childDevices.find{it.deviceNetworkId == "${app.id}.${ks}"}
-    def masterDevice = childDevices.find{it.deviceNetworkId == "${app.id}.0"}    
+		def childDevice = getChildDevice("${app.id}.${ks}")	// childDevices.find{it.deviceNetworkId == "${app.id}.${ks}"}
+    def masterDevice = getChildDevice("${app.id}.0")		// childDevices.find{it.deviceNetworkId == "${app.id}.0"}   
     def name = 'switch'
     def value
     def message
@@ -821,7 +973,8 @@ void zoneOnOff(dni, onoff, level) {
             zone: zone,
             zonestate: onoff,
             zonetime: level*60
-        ]
+        ],
+		timeout: 30
     ]
 
     sendPost(POSTparams)
@@ -847,7 +1000,8 @@ void scheduleOnOff(name, onoff){
                     body: [
                         scheduleID: scheduleID,
                         onoff: onoff
-                    ]
+                    ],
+					timeout: 30
                 ]
 
     sendPost(POSTparams)
@@ -859,7 +1013,8 @@ void runAll(runtime){
                     uri: 'https://api.spruceirrigation.com/v2/runall',
                     body: [
                         zonetime: runtime
-                    ]
+                    ],
+					timeout: 30
                 ]
 
     sendPost(POSTparams)
@@ -870,7 +1025,8 @@ void send_pause(pausetime = 0){
                     uri: 'https://api.spruceirrigation.com/v2/pause',                    
                     body: [
                         pausetime: pausetime*60
-                    ]
+                    ],
+					timeout: 30
                 ]
 
     sendPost(POSTparams)
@@ -878,7 +1034,8 @@ void send_pause(pausetime = 0){
 
 void send_resume(){
 	def POSTparams = [
-                    uri: 'https://api.spruceirrigation.com/v2/resume'
+                    uri: 'https://api.spruceirrigation.com/v2/resume',
+					timeout: 30
                 ]
 
     sendPost(POSTparams)
@@ -886,7 +1043,8 @@ void send_resume(){
 
 void send_stop(){	
 	def POSTparams = [
-                    uri: 'https://api.spruceirrigation.com/v2/stop'
+                    uri: 'https://api.spruceirrigation.com/v2/stop',
+					timeout: 30
                 ]
 
     sendPost(POSTparams)
@@ -913,7 +1071,7 @@ def sendPost(POSTparams) {
     } 
     catch (groovyx.net.http.HttpResponseException error) {
         if (error.statusCode == 401) {    // Unauthorized
-            log.info "${app.label} sendPost: Refreshing authorization token"
+            log.info "${app.label} - sendPost: Refreshing authorization token"
             refreshAuthToken()
             retryInitialRequest(POSTparams)
         } else {
@@ -985,7 +1143,8 @@ def callback() {
                     client_id : getClientId(),
                     client_secret: getClientSecret(),
                     redirect_uri: getFullApiServerUrl() + "/oauth/callback?access_token=${atomicState.accessToken}"
-                ]
+                ],
+			timeout: 30
         ]
         
         httpPost(tokenParams) { resp ->
@@ -1006,7 +1165,8 @@ def callback() {
                 body: [
                 	hubitat_endpoint: getFullApiServerUrl(),
                     hubitat_token: atomicState.accessToken
-                ]
+                ],
+				timeout: 30
             ]
             
             try{
@@ -1034,7 +1194,8 @@ def callback() {
 private refreshAuthToken() {
     def refreshParams = [        
         uri: "https://app.spruceirrigation.com/oauth/token",
-        body: [grant_type: "refresh_token", refresh_token: atomicState.refreshToken, client_id: getClientId(), client_secret: getClientSecret()]
+        body: [grant_type: "refresh_token", refresh_token: atomicState.refreshToken, client_id: getClientId(), client_secret: getClientSecret()],
+		timeout: 	30
     ]
     try{
         def jsonMap

--- a/apps/Spruce Connect.src
+++ b/apps/Spruce Connect.src
@@ -25,6 +25,9 @@
  *       - pause() changed to hold(), hubitat throws error when pause command executed
  *       - update events to master
  *
+ * BAB updates:
+ * v1.3bab - Create more descriptive device.labels for Controller, Zones and Spruce Pause devices
+ *         - (NOTE: Spruce wifi master now uses the Pause device.deviceNetworkId instead of device.name)
  *
  */
 
@@ -53,7 +56,7 @@ preferences (oauthPage: "authPage") {
 }
 
 def authPage(){
-    atomicState.versionText = "Spruce-Connect v1.3\nRelease: 11.2019"
+    atomicState.versionText = "Spruce-Connect v1.3BAB\nRelease: 12.2019"
     atomicState.clientId = "hubitat"
     atomicState.clientSecret = "6137b7f5efabd2f8a82f80c95f6dd50807426f72"
     
@@ -263,13 +266,19 @@ private void createChildDevices(){
     if(atomicState.zoneUpdate == true){
     	removeChildDevices()
     
-        //set Spruce Controller Name        
-        addChildDevice("plaidsystems", "Spruce wifi master", "${app.id}.0", null, [completedSetup: true, label: "${settings.controller}", isComponent: false, name: "wifi"])
+        //set Spruce Controller Name  
+		String controllerName = settings.controller
+		if (!controllerName.contains("Spruce")) controllerName = "Spruce " + controllerName
+		if (!controllerName.contains("Controller")) controllerName = controllerName + " Controller"
+        addChildDevice("plaidsystems", "Spruce wifi master", "${app.id}.0", null, [completedSetup: true, label: "${controllerName}", isComponent: false, name: "Spruce WiFi Controller"])
 
-        //Create children   
+        //Create children
+		String prefix = controllerName.endsWith(' Controller') ? controllerName - " Controller" : controllerName
         def tempZoneMap = atomicState.zoneMap
-        tempZoneMap.each{            
-            addChildDevice("plaidsystems", "Spruce wifi zone", "${app.id}.${it.key}", null, [completedSetup: true, label: "${tempZoneMap[it.key]['zone_name']}", isComponent: false, name: "Zone ${it.key}"])
+        tempZoneMap.each{
+			String label = "${prefix} ${it.key} - ${tempZoneMap[it.key]['zone_name']}"
+			String name = "${controllerName} Zone ${it.key}"
+            addChildDevice("plaidsystems", "Spruce wifi zone", "${app.id}.${it.key}", null, [completedSetup: true, label: label, isComponent: false, name: name])
         }
     }
     if (atomicState.manUpdate == true) child_schedules("${app.id}.0")
@@ -296,13 +305,19 @@ def child_schedules(dni){
 	def childDevice = childDevices.find{it.deviceNetworkId == dni}
     log.debug "${childDevice}"
     
-    if(settings.pause == true) childDevice.createScheduleDevices("${app.id}", 99, 0, "Spruce Pause")
+    // Pause Device for this Controller
+	if(settings.pause == true) {
+		String controllerName = settings.controller.displayName
+		if (!controllerName.startsWith("Spruce ")) controllerName = "Spruce " + controllerName
+		if (!controllerName.endsWith(" Controller")) controllerName = controllerName + " Controller"
+		childDevice.createScheduleDevices("${app.id}", 99, 0, "${controllerName} Pause")
+	}
     
     //add manual schedules
     def manualschs = atomicState.manualMap    
     manualschs.each{        
     	childDevice.createScheduleDevices("${app.id}", it.key, manualschs[it.key]["scheduleid"], manualschs[it.key]["name"])        
-        }
+    }
 }
 
 //add zone settings to child tile

--- a/apps/Spruce Connect.src
+++ b/apps/Spruce Connect.src
@@ -28,6 +28,8 @@
  * BAB updates:
  * v1.3bab - Create more descriptive device.labels for Controller, Zones and Spruce Pause devices
  *         - (NOTE: Spruce wifi master now uses the Pause device.deviceNetworkId instead of device.name)
+ * v1.4bab - Added debug on/off, cleaned up settings collection pages
+ * v.15bab - Handle sensor device rename
  *
  */
 
@@ -43,8 +45,9 @@ definition(
     oauth: true,
     singleInstance: true
 )
-{    
-}
+String getVersionText()     {return "Spruce-Connect v1.5bab\nRelease: 05.2020"}
+String getClientId()        {return "hubitat"}
+String getClientSecret()    {return "6137b7f5efabd2f8a82f80c95f6dd50807426f72"}
 
 //-----------------pages----------------------------
 preferences (oauthPage: "authPage") {
@@ -56,9 +59,7 @@ preferences (oauthPage: "authPage") {
 }
 
 def authPage(){
-    atomicState.versionText = "Spruce-Connect v1.3BAB\nRelease: 12.2019"
-    atomicState.clientId = "hubitat"
-    atomicState.clientSecret = "6137b7f5efabd2f8a82f80c95f6dd50807426f72"
+
     
     if(!atomicState.accessToken) atomicState.accessToken = createAccessToken()	//set = so token is saved to atomicState 
     
@@ -84,9 +85,9 @@ def pageConnect(){
         def redirectUrl = oauthInitUrl()
         
         log.debug "redirectUrl ${redirectUrl}"
-        dynamicPage(name: "pageConnect", title: "Connect Account",  uninstall: false, install:false) {
+        dynamicPage(name: "pageConnect", title: "<b>Connect Account<b/>",  uninstall: false, install:false) {
             section {
-                href url: redirectUrl, style:"embedded", required:false, title:"Connect Spruce Account", image: 'http://www.plaidsystems.com/smartthings/st_spruce_leaf_250f.png', description: "Login to grant access"
+                href url: redirectUrl, style:"embedded", required:false, title:"<b>Connect Spruce Account</b>", image: 'http://www.plaidsystems.com/smartthings/st_spruce_leaf_250f.png', description: "Login to grant access"
             }
         }
     }    
@@ -98,10 +99,10 @@ def pageController(){
     	def select_device = getSpruceDevices()
         log.debug select_device
         dynamicPage(name: "pageController", uninstall: true, install:false, nextPage: "pageDevices") {            
-            section("Select Spruce Controller\n to connect with Hubitat") {
-            	input(name: "controller", title:"Select Spruce Controller:", type: "enum", required:true, multiple:false, description: "Tap to choose", options:select_device)
+            section("<b>Spruce Controller<b>") {
+            	input(name: "controller", title:"<b>Select Spruce Controller:</b>", type: "enum", required:true, multiple:false, description: "Click to choose", options:select_device)
     		}
-            section("${atomicState.versionText}"){}
+            section("${getVersionText()}"){}
         }
     }    
     else pageDevices()
@@ -111,21 +112,29 @@ def pageDevices(){
 	if (atomicState.authToken && controllerSelected() && getControllerSettings()){
       log.debug atomicState.zoneUpdate
       log.debug "pageDevices"
-        dynamicPage(name: "pageDevices", uninstall: true, install:true) {
-        	if(atomicState.zoneUpdate == true) section("Device changes found, device tiles will be updated! \n\nDevice tiles and automations must be updated!\n"){}
-         	section("Select settings for connected devices\nConnected controller: ${settings.controller}\nConnected zones: ${zoneList()}") {
-                input "sendPushMessage", "capability.notification", title: "Notification Devices: Hubitat PhoneApp or Pushover", multiple: true, required: false
-                input(name: "notifications", title:"Select Notifications to send:", type: "enum", required:false, multiple:true, description: "Tap to choose", options: ['Schedule','Zone','Valve Fault'])                
+        dynamicPage(name: "pageDevices", title:"<h3><b>${getVersionText()}</b></h3>", uninstall: true, install:true) {
+        	if(atomicState.zoneUpdate == true) section("<b>Device changes found, device tiles will be updated!</b>\n\nDevice tiles and automations must be updated!\n"){}
+            section("<b>Settings for Connected devices\nConnected controller:</b> ${settings.controller}\n<b>Connected zones:</b> ${zoneList()}") {}
+			section("<b>Notifications</b>") {
+                input "sendPushMessage", "capability.notification", title: "<b>Notification Devices</b>", descriptionText: "Select Hubitat notification devices", multiple: true, required: false
+                input(name: "notifications", title:"<b>Notifications to Send</b>", type: "enum", required:false, multiple:true, description: "Select desired notifications", options: ['Schedule','Zone','Valve Fault'])                
             }
-            section("Hubitat Spruce Sensors that will report to Spruce Cloud:") {
-                input "sensors", "capability.relativeHumidityMeasurement", title: "Spruce Moisture sensors:", required: false, multiple: true
+            section("<b>Hubitat Spruce Sensors</b>") {
+                paragraph "Select local Spruce Sensors that will be reported to Spruce Cloud:"
+                input "sensors", "device.SpruceSensor", title: "<b>Spruce Moisture Sensors:</b>", required: false, multiple: true
             }
-            section("Pause and resume\n\nUse the Spruce Pause control with Hubitat Rule Machine\nOr add contact sensors without any rules") {
-                input(name: "pause", title:"Turn on to create Spruce Pause control that is accesible from automation routines to pause and resume water", type: 'bool')
-            	input "contacts", "capability.contactSensor", title: "Contact sensors will pause or resume water:", required: false, multiple: true
-                input "delay", "number", title: "The delay in minutes that water will resume after the contact is closed, default=5, max=119", required: false, range: '0..119'
+                section("<b>Pause and resume</b>") {
+                paragraph "Use the Spruce Pause control with Hubitat Rule Machine, or add contact sensors without any rules to pause & resume irrigation."
+                input(name: "pause", title:"<b>Create the Spruce Pause control</b>", type: 'bool', defaultValue: false)
+            	input "contacts", "capability.contactSensor", title: "<b>Contact Sensors</b>", descriptionText: "Select contact sensors that will pause watering when open", required: false, multiple: true
+				if (settings.contacts) input "delay", "number", title: "<b>Resume Watering Delay</b> (in minutes, default=5, max=119)", 
+					descriptionText:"Delay after the contact${contacts?.size()>1?'s are':' is'} closed</b>\n(Delay in minutes default=5, max=119)", defaultValue: 5, required: false, range: '0..119'
             }
-            section("${atomicState.versionText}"){}
+            section('') {
+                input "debugOn", "bool", title: "<b>Enable debug logging</b>", defaultValue: true
+		        input "infoOn", "bool", title: "<b>Enable descriptionText logging?</b>", defaultValue: true
+            }
+            section("${getVersionText()}"){}
         }   
     }    
     else {
@@ -137,11 +146,12 @@ def pageDevices(){
 def zoneList(){
 	def tempZoneMap = atomicState.zoneMap
     def zoneString = ""
+	def comma = ''
     tempZoneMap.sort().each{
         def zone_name = "Zone ${it.key}"
         if ("${tempZoneMap[it.key]['zone_name']}" != 'null') zone_name = "${tempZoneMap[it.key]['zone_name']}"
-    	zoneString += zone_name
-        zoneString += ","
+    	zoneString += (comma + zone_name)
+        if (!comma) comma = ", "
     }
     return zoneString;
 }
@@ -201,6 +211,12 @@ def updated() {
 
 def initialize() {	
     log.debug "initialize"
+	if (infoOn) log.info "${linkText} info logging enabled"
+	if (debugOn) log.info "${linkText} debug logging enabled for 30 minutes"
+	atomicState.versionText = getVersionText()
+	atomicState.clientId = getClientId()
+	atomicState.clientSecret = getClientSecret()
+	
     atomicState.zones_on = 0
     
     if (settings.sensors) getSensors()
@@ -211,11 +227,18 @@ def initialize() {
     	log.debug getApiServerUrl()
         addDevices()
     	createChildDevices()        
-	}    
+	}  
+    if (debugOn) runIn(1800, debugOff, [overwrite: true])
+}
+
+def debugOff(){
+    log.debug "debug logging disabled..."
+    app.updateSetting("debugOn",[value:"false",type:"bool"])
+    settings.debugOn = false
 }
 
 def uninstalled() {
-    log.debug "uninstall"
+    if (debugOn) log.debug "uninstall"
     removeChildDevices()   
 }
 
@@ -232,7 +255,7 @@ def getSpruceDevices(){
 
 //sensor subscriptions
 def getSensors(){    
-    log.debug "getSensors: " + settings.sensors    
+    if (debugOn) log.debug "getSensors: " + settings.sensors    
     
     def tempSensors = [:]
     settings.sensors.each{
@@ -247,7 +270,7 @@ def getSensors(){
 
 //contact subscriptions
 def getContacts(){    
-    log.debug "getContacts: " + settings.contacts    
+    if (debugOn) log.debug "getContacts: " + settings.contacts    
     
     def tempContacts = [:]
     settings.contacts.each{
@@ -262,7 +285,7 @@ def getContacts(){
 
 //create zone tiles children
 private void createChildDevices(){
-	log.debug "create zone children ${atomicState.zoneUpdate} with ${app.id}"
+	if (debugOn) log.debug "create zone children ${atomicState.zoneUpdate} with ${app.id}"
     if(atomicState.zoneUpdate == true){
     	removeChildDevices()
     
@@ -287,11 +310,11 @@ private void createChildDevices(){
 
 //remove zone tiles children
 private removeChildDevices() {
-	log.debug "remove children"
+	if (debugOn) log.debug "remove children"
 	
     //get and delete children avoids duplicate children
     def children = getChildDevices()  
-    log.debug children
+    if (debugOn) log.debug children
     if(children != null){
         children.each{
         	deleteChildDevice(it.deviceNetworkId)
@@ -301,13 +324,13 @@ private removeChildDevices() {
 
 //add child device tiles to master
 def child_schedules(dni){
-	log.debug "get child tiles for master"
+	if (debugOn) log.debug "get child tiles for master"
 	def childDevice = childDevices.find{it.deviceNetworkId == dni}
-    log.debug "${childDevice}"
+    if (debugOn) log.debug "${childDevice}"
     
     // Pause Device for this Controller
 	if(settings.pause == true) {
-		String controllerName = settings.controller.displayName
+		String controllerName = settings.controller
 		if (!controllerName.startsWith("Spruce ")) controllerName = "Spruce " + controllerName
 		if (!controllerName.endsWith(" Controller")) controllerName = controllerName + " Controller"
 		childDevice.createScheduleDevices("${app.id}", 99, 0, "${controllerName} Pause")
@@ -323,12 +346,12 @@ def child_schedules(dni){
 //add zone settings to child tile
 def child_zones(dni){
 	def childDevice = childDevices.find{it.deviceNetworkId == dni}
-    log.debug "${childDevice.deviceNetworkId}"
+    if (debugOn) log.debug "${childDevice.deviceNetworkId}"
         
     def tempZoneMap = atomicState.zoneMap    
     tempZoneMap.each{    	
         if("${app.id}.${it.key}" == childDevice.deviceNetworkId){
-        	log.debug it.key
+        	if (debugOn) log.debug it.key
             childDevice.childSettings(it.key, tempZoneMap[it.key])
         }
     }    
@@ -341,7 +364,7 @@ def addDevices(){
     def key = atomicState.authToken
     def tempSensorMap = atomicState.sensors
     tempSensorMap.each{
-    	log.debug "Add Sensor to DB ${it.key}"
+    	//if (debugOn) log.debug "Add Sensor to DB ${it.key}"
     	def POSTparams = [
             uri: "https://api.spruceirrigation.com/v2/sensor",
             headers: [ 	"Authorization": "Bearer ${key}"],
@@ -353,13 +376,14 @@ def addDevices(){
         ]
         //sendPost(POSTparams)
         try{
-            httpPost(POSTparams){
-                resp -> //resp.data {
-                    log.debug "${resp.data}"               
+            httpPost(POSTparams) { resp -> //resp.data {
+                if (debugOn) {
+                	log.debug "Add Sensor to DB ${it.key}: ${resp?.data?.message}"
+				}
             }                
         } 
         catch (e) {
-            log.debug "send DB error: $e"
+            log.warn "send DB error: $e"
         }
     }    
 
@@ -372,7 +396,7 @@ def getControllerList(){
 	def key = atomicState.authToken
     def tempMap = [:]
     def newuri =  "https://api.spruceirrigation.com/v2/controllers"    
-    log.debug newuri
+    if (debugOn) log.debug newuri
     
     def GETparams = [
         uri: newuri,		
@@ -380,7 +404,7 @@ def getControllerList(){
     ]
 
     try{ httpGet(GETparams) { resp ->	
-    	log.debug "resp-> ${resp.data}"        
+    	if (debugOn) log.debug "resp-> ${resp.data}"        
         resp.data.each{        	
             tempMap += ["${resp.data[it.key]['controller_name']}": it.key]
         }        
@@ -396,7 +420,7 @@ def getControllerList(){
 
 //check for pre-set schedules
 def getControllerSettings(){
-	log.debug "-----------settings----------------"
+	if (debugOn) log.debug "-----------settings----------------"
     def respMessage = ""
     def key = atomicState.authToken
 
@@ -404,13 +428,13 @@ def getControllerSettings(){
    	def tempSwitch = atomicState.switches    
     
     tempSwitch.each{
-        log.debug "key ${it.key} ${it.value}"
+        if (debugOn) log.debug "key ${it.key} ${it.value}"
         if (it.key == settings.controller) controller_id = it.value
     }
    
     def newuri =  "https://api.spruceirrigation.com/v2/controller_settings?controller_id="
 	newuri += controller_id
-    log.debug newuri
+    if (debugOn) log.debug newuri
         
     def scheduleType
     def scheduleID = []
@@ -428,7 +452,7 @@ def getControllerSettings(){
 
     try{ httpGet(GETparams) { resp ->	
         //get schedule list
-        log.debug "Get setting for ${resp.data.controller_name}"
+        if (debugOn) log.debug "Get setting for ${resp.data.controller_name}"
         def i = 1
         def j = 1
         
@@ -479,7 +503,7 @@ def getControllerSettings(){
         else return false
     }
     
-    log.debug tempManMap
+    if (debugOn) log.debug tempManMap
     
     if(atomicState.manualMap != null){
         if ("${tempManMap.sort()}" != "${atomicState.manualMap.sort()}") atomicState.manualUpdate = true
@@ -515,7 +539,7 @@ def getControllerSettings(){
 //***************** event handlers *******************************
 
 def parse(description) {
-	log.debug(description)
+	if (debugOn) log.debug(description)
 }
 
 def getScheduleName(scheduleid){	
@@ -536,49 +560,60 @@ def getScheduleName(scheduleid){
 
 //sensor evts
 def sensorHandler(evt) {
-    log.debug "sensorHandler: ${evt.device}, ${evt.name}, ${evt.value}"
+    log.info "${app.label} sensorHandler: ${evt.device}, ${evt.name}: ${evt.value}"
     
-    def device = atomicState.sensors["${evt.device}"]
-    def value = evt.value
-    def uri = "https://api.spruceirrigation.com/v2/"
-    
-    if (evt.name == "humidity") uri += "moisture"
-    
-    if (evt.name == "temperature"){
-    	uri += "temperature"
-        if (evt.unit == "C") value = evt.value.toInteger() * 9/5 + 32
-    }
-        
-    //added for battery
-    if (evt.name == "battery"){
-        uri += "battery"
-        value = evt.value.toInteger() * 5 + 2500
-    }
-            
-    def POSTparams = [
-                    uri: uri,
-                    body: [
-                        deviceid: device,
-                        value: value                        
-                    ]
-                ]
+    String device = atomicState.sensors["${evt.device}"] as String
+	if (!device && settings.sensors) {
+		// Oops - looks like we had a name change - rebuild the name/id Map
+		def tempSensors = [:]
+    	settings.sensors.each{
+    		tempSensors[it]= (it.device.zigbeeId)
+        }
+    	atomicState.sensors = tempSensors
+		device = tempSensors["${evt.device}"] as String
+	}
+	if (device) {
+		def value = evt.value
+		def uri = "https://api.spruceirrigation.com/v2/"
 
-	sendPost(POSTparams)
+		if (evt.name == "humidity") {
+			uri += "moisture"
+		} else if (evt.name == "temperature"){
+			uri += "temperature"
+			if (evt.unit == "C") value = evt.value * 9/5 + 32 // was evt.value.toInteger() - no need to truncate the value like that
+		} else if (evt.name == "battery"){
+			//added for battery
+			uri += "battery"
+			value = evt.value.toInteger() * 5 + 2500
+		}
+
+		def POSTparams = [
+			uri: uri,
+			body: [
+				deviceid: device,
+				value: value                        
+			]
+		]
+
+		sendPost(POSTparams)
+	} else {
+		if (debugOn) log.debug "No deviceId found for ${evt.device}."
+	}
 }
 
 //contact evts
 def contactHandler(evt) {
-    log.debug "contactHandler: ${evt.device}, ${evt.name}, ${evt.value}"
+    log.info "${app.label} contactHandler: ${evt.device}, ${evt.name}, ${evt.value}"
     
     def device = atomicState.contacts["${evt.device}"]    
     def value = evt.value
         
     def childDevice = childDevices.find{it.deviceNetworkId == "${app.id}.0"}
     
-    log.debug "Found ${childDevice}"
+    if (debugOn) log.debug "Found ${childDevice}"
     if (childDevice != null){    	
         def result = [name: evt.name, value: value, descriptionText: evt.name, isStateChange: true, displayed: false]
-        log.debug result
+        if (debugOn) log.debug result
         childDevice.generateEvent(result)
     }
     
@@ -598,7 +633,7 @@ def contactHandler(evt) {
 
 //refresh settings
 void getChildren(){
-	log.debug "Update Settings"
+	if (debugOn) log.debug "Update Settings"
     
 	if (getControllerSettings()){
 		def children = getChildDevices()
@@ -613,7 +648,7 @@ void getChildren(){
 
 //big tile events
 def event(){
-	log.debug "cloud event: ${params.command}"
+	if (debugOn) log.debug "cloud event: ${params.command}"
     def command = params.command
 	def event = command.split(',')
     
@@ -621,7 +656,7 @@ def event(){
     if (masterDevice != null){  	
         def scheduleName = getScheduleName(event[2])
         def result = [name: 'status', value: "${event[0]}", descriptionText: "${scheduleName} starting\n${event[1]}", isStateChange: true, displayed: false]
-        log.debug result        
+        if (debugOn) log.debug result        
         masterDevice.generateEvent(result)
         
         def tempManualMap = atomicState.manualMap        
@@ -636,10 +671,10 @@ def event(){
 
 //rain sensor onoff
 def rain(){
-	log.debug(params.command)
+	if (debugOn) log.debug(params.command)
     // use the built-in request object to get the command parameter
     def command = params.command
-    log.debug "Spruce incoming rain=>>  ${command}"
+    if (debugOn) log.debug "Spruce incoming rain=>>  ${command}"
     
     def zoneonoff = command.split(',')
             
@@ -650,7 +685,7 @@ def rain(){
     def masterDevice = childDevices.find{it.deviceNetworkId == "${app.id}.0"}
     
     def result = [name: name, value: value, descriptionText: "${masterDevice} ${message}", isStateChange: true, displayed: true]
-    log.debug result
+    if (debugOn) log.debug result
     masterDevice.generateEvent(result)
     
     return [error: false, return_value: 1]
@@ -659,10 +694,10 @@ def rain(){
 //pause onoff
 //changed to hold, hubitat throws error when pause command executed
 def hold(){
-	log.debug(params.command)
+	if (debugOn) log.debug(params.command)
     // use the built-in request object to get the command parameter
     def command = params.command
-    log.debug "Spruce incoming pause=>>  ${command}"
+    if (debugOn) log.debug "Spruce incoming pause=>>  ${command}"
     
     def zoneonoff = command.split(',')
             
@@ -673,7 +708,7 @@ def hold(){
     def masterDevice = childDevices.find{it.deviceNetworkId == "${app.id}.0"}
     
     def result = [name: name, value: value, descriptionText: "${masterDevice} ${message}", isStateChange: true, displayed: true]
-    log.debug result
+    if (debugOn) log.debug result
     masterDevice.generateEvent(result)
     
     return [error: false, return_value: 1]
@@ -683,10 +718,10 @@ def hold(){
 
 //turn on/off zones of child devices
 def zone_state(){
-	log.debug "cloud zone_state: ${params.command}"
+	if (debugOn) log.debug "cloud zone_state: ${params.command}"
     // use the built-in request object to get the command parameter
     def command = params.command
-    log.debug "Spruce incoming zone=>>  ${command}"
+    if (debugOn) log.debug "Spruce incoming zone=>>  ${command}"
     
     //check sz to filter out command
     def zoneonoff = command.split(',')
@@ -725,7 +760,7 @@ def zone_state(){
     
     if (zone_on < 0) zone_on = 0
     if (ks == "0" && value == 'off') zone_on = 0
-    log.debug "zone_on count: ${zone_on}"
+    if (debugOn) log.debug "zone_on count: ${zone_on}"
     /*
     if (atomicState.zones_on == 0 && zone_on == 1) masterDevice.generateEvent([name: 'switch', value: "on", descriptionText: "${settings.controller} ${message}", isStateChange: true, displayed: true])
     else if (atomicState.zones_on >= 1 && zone_on == 0) masterDevice.generateEvent([name: 'switch', value: "off", descriptionText: "${settings.controller} ${message}", isStateChange: true, displayed: true])    
@@ -745,7 +780,7 @@ def zone_state(){
     
     def zoneResult = [name: name, value: value, descriptionText: "${childDevice} ${message}", isStateChange: true, displayed: true]
     
-    //log.debug zoneResult
+    //if (debugOn) log.debug zoneResult
     childDevice.generateEvent(zoneResult)
     
     def masterResult = [name: name, value: value, descriptionText: "${childDevice} ${message}", isStateChange: true, displayed: true]
@@ -773,12 +808,12 @@ def zone_state(){
 
 //turn on/off zones to cloud
 void zoneOnOff(dni, onoff, level) {
-    log.debug "Cloud zoneOnOff ${dni} ${onoff} ${level}"
+    if (debugOn) log.debug "Cloud zoneOnOff ${dni} ${onoff} ${level}"
    	
     String zone_dni = "${dni}"
     def zone = zone_dni[-2..-1]
     
-    log.debug zone
+    if (debugOn) log.debug zone
 
     def POSTparams = [
         uri: 'https://api.spruceirrigation.com/v2/zone',
@@ -797,7 +832,7 @@ void scheduleOnOff(name, onoff){
 	def OnOff = 'stopped'
     if (onoff.toInteger() == 1) OnOff = 'started'
     def message = "Schedule ${name} ${OnOff}"
-    log.debug "scheduleOnOff ${name} ${OnOff}"
+    if (debugOn) log.debug "scheduleOnOff ${name} ${OnOff}"
     
     note('Schedule',message)
     
@@ -860,7 +895,7 @@ void send_stop(){
 
 //************* notifications to device, pushed if requested ******************
 def note(type, message){	
-	log.debug "note ${type} ${message}"
+	if (debugOn) log.debug "note ${type} ${message}"
 	if(sendPushMessage && settings.notifications && settings.notifications.contains(type)) sendPushMessage.deviceNotification("${message}")
 }
 
@@ -868,20 +903,28 @@ def note(type, message){
 
 def sendPost(POSTparams) {
     POSTparams.put( "headers", [ "Authorization": "Bearer ${atomicState.authToken}", "Content-Type": "application/x-www-form-urlencoded"] )
-    //log.debug POSTparams
+    //if (debugOn) log.debug POSTparams
 	try{
         httpPost(POSTparams){
             resp ->
-            log.debug "Post Response ${resp.data}"
-            if ("${resp.data.error}" == 'true') note('error', "${resp.data.message}")
+            //if (debugOn) log.debug "Post Response ${resp.data}"
+			if ("${resp.data.error}" == 'true') note('error', "${resp.data.message}\n ${POSTparams}")
         }                
     } 
+    catch (groovyx.net.http.HttpResponseException error) {
+        if (error.statusCode == 401) {    // Unauthorized
+            log.info "${app.label} sendPost: Refreshing authorization token"
+            refreshAuthToken()
+            retryInitialRequest(POSTparams)
+        } else {
+            log.warn "send DB error, statusCode: ${error.statusCode}, error: $error"
+        }
+    }
     catch (error) {
-        log.debug "send DB error: $error"        
+        log.warn "send DB error: $error"
         refreshAuthToken()
         retryInitialRequest(POSTparams)
     }
-   	
 }
 
 def retryInitialRequest(POSTparams) {
@@ -889,11 +932,11 @@ def retryInitialRequest(POSTparams) {
     try{
         httpPost(POSTparams){
             resp ->
-            log.debug "${resp.data}"               
+            if ("${resp.data.error}" == 'true') note('error', "${resp.data.message}")              
         }                
     } 
     catch (error) {
-        log.debug "send DB error: $error"        
+        log.warn "retry send DB error: $error"        
     }
 }
 
@@ -907,15 +950,15 @@ def oauthInitUrl(){
 	def oauthParams = [
         response_type: "code",
         scope: "basic",
-        client_id: atomicState.clientId,
-        client_secret: atomicState.clientSecret,
+        client_id: getClientId(),
+        client_secret: getClientSecret(),
         state: atomicState.oauthInitState,
         redirect_uri: getFullApiServerUrl() + "/oauth/callback?access_token=${atomicState.accessToken}"
     ]
 	def apiEndpoint = "https://app.spruceirrigation.com/oauth"
     def oAuthInitURL = "${apiEndpoint}/authorize?${toQueryString(oauthParams)}"
     
-    log.debug "oAuthInitURL ${oAuthInitURL}"
+    if (debugOn) log.debug "oAuthInitURL ${oAuthInitURL}"
     return "${oAuthInitURL}"
     
 }
@@ -926,11 +969,11 @@ String toQueryString(Map m) {
 }
 
 def callback() {
-    log.debug "callback()>> params: $params, params.code ${params.code}"
+    if (debugOn) log.debug "callback()>> params: $params, params.code ${params.code}"
     
     def code = params.code
     def oauthState = params.state
-    log.debug "callback code ${code} state ${oauthState}"
+    if (debugOn) log.debug "callback code ${code} state ${oauthState}"
     // Validate the response from the third party by making sure oauthState == state.oauthInitState as expected
     if (oauthState == atomicState.oauthInitState){
         def tokenParams = [
@@ -939,8 +982,8 @@ def callback() {
                     grant_type: "authorization_code",
                     code : "${code}",
                     scope : "basic",
-                    client_id : atomicState.clientId,
-                    client_secret: atomicState.clientSecret,
+                    client_id : getClientId(),
+                    client_secret: getClientSecret(),
                     redirect_uri: getFullApiServerUrl() + "/oauth/callback?access_token=${atomicState.accessToken}"
                 ]
         ]
@@ -949,13 +992,13 @@ def callback() {
         	atomicState.refreshToken = resp.data.refresh_token
             atomicState.authToken = resp.data.access_token           
         }
-        log.debug "tokens refresh ${atomicState.refreshToken} auth ${atomicState.authToken} put? ${atomicState.accessTokenPut}"
+        if (debugOn) log.debug "tokens refresh ${atomicState.refreshToken} auth ${atomicState.authToken} put? ${atomicState.accessTokenPut}"
         
         //send access_token to spruce        
         if (atomicState.authToken && !atomicState.accessTokenPut) {
         	
             def accessToken_url = "https://api.spruceirrigation.com/hubitat/accesstoken"
-            log.debug accessToken_url
+            if (debugOn) log.debug accessToken_url
             
             def accessParams = [
             	uri: accessToken_url,
@@ -968,16 +1011,16 @@ def callback() {
             
             try{
                 httpPost(accessParams) { resp ->
-            	    log.debug resp.data
+            	    if (debugOn) log.debug resp.data
                     if (resp.data.error == false){
-                        log.debug "success"
+                        if (debugOn) log.debug "success"
                         atomicState.accessTokenPut = true
                         success()                        
                     }
                     else fail()
                 }
             } catch(Exception e){
-                log.debug e
+                log.error e
                 fail()
             }
             
@@ -991,13 +1034,13 @@ def callback() {
 private refreshAuthToken() {
     def refreshParams = [        
         uri: "https://app.spruceirrigation.com/oauth/token",
-        body: [grant_type: "refresh_token", refresh_token: atomicState.refreshToken, client_id: atomicState.clientId, client_secret: atomicState.clientSecret]
+        body: [grant_type: "refresh_token", refresh_token: atomicState.refreshToken, client_id: getClientId(), client_secret: getClientSecret()]
     ]
     try{
         def jsonMap
-        log.debug refreshParams
+        if (debugOn) log.debug refreshParams
         httpPost(refreshParams) { resp ->
-            log.debug resp.data
+            if (debugOn) log.debug resp.data
             if(resp.status == 200)
             {
                 jsonMap = resp.data
@@ -1010,7 +1053,7 @@ private refreshAuthToken() {
     	}
     }
     catch (error) {
-        log.debug "token refresh error: $error"
+        log.warn "token refresh error: $error"
         return false
     }
     return true

--- a/drivers/Spruce sensor.src
+++ b/drivers/Spruce sensor.src
@@ -40,7 +40,8 @@
  - Added Notes preference/state variable for Location, Battery Change Date, etc.
  - Eliminate consecutive duplicate events
  - removed debug refreshAttributes()
- - stop creating new events for duplicate values recieved within 10 seconds of each other 
+ - stop creating new events for duplicate values recieved within 10 seconds of each other
+ - added setInterval command, call update() and then poll()
 
  */
  
@@ -92,9 +93,9 @@ def initialize() {
 	if (debugOn) log.info "${linkText} debug logging enabled for 1 hour"
 	log.info "${linkText} updated, settings: ${settings}"
 	
-	String descriptionText = "${linkText} settings changed, will update sensor at next report. Measurement Interval set to ${interval} minutes, update state is 1"
+	String descriptionText = "${linkText} settings changed, will update sensor at next report. Measurement Interval set to ${settings.interval} minutes, update state is 1"
 	sendEvent(name: 'update', value: 1, descriptionText: descriptionText)
-	sendEvent(name: 'interval', value: interval, descriptionText: "${linkText} Measurement Interval updated")
+	sendEvent(name: 'interval', value: settings.interval, descriptionText: "${linkText} Measurement Interval updated")
 	if (infoOn) log.info descriptionText
 
 	// handle reference temperature / tempOffset automation
@@ -381,6 +382,7 @@ def setInterval(value) {
         device.updateSetting('interval', newValue)
         settings.interval = newValue
         updated()
+		poll()
     }
 }
 
@@ -427,9 +429,9 @@ def configure() {
     //set minReport = measurement in minutes
     def minReport = 10
     def maxReport = 610			// 10 hours and 10 minutes
-	if (interval != null) {
-        minReport = interval
-        maxReport = interval * 61
+	if (settings.interval != null) {
+        minReport = settings.interval
+        maxReport = settings.interval * 61
     }
 	
     if (debugOn) log.debug "zigbeeId ${device.zigbeeId}"

--- a/drivers/Spruce sensor.src
+++ b/drivers/Spruce sensor.src
@@ -28,10 +28,23 @@
  -------11/2019 Updates--------
  -port to hubitat
 
+ -------12/2019 Updates--------
+ - Refactored to Hubitat "standards"
+   - debugOn, infoOn both on at install
+   - debugOff after 1 hour
+   - use referenceTemp to calculate tempOffset from state.sensorTemp
+   - move tempOffset attribute to state.tempOffset
+   - added importUrl
+ - Changed all rounding to use BigDecimal.ROUND_HALF_UP
+ - Globally preserve 2 decimal points of temperature precision for both Celsius and Fahrenheit (was C only)
+ - Added Notes preference/state variable for Location, Battery Change Date, etc.
+ - Eliminate consecutive duplicate events
+
  */
  
 metadata {
-    definition (name: "Spruce Sensor", namespace: "plaidsystems", author: "Plaid Systems") {
+    definition (name: "Spruce Sensor", namespace: "plaidsystems", author: "Plaid Systems",
+			    importUrl: "https://raw.githubusercontent.com/PlaidSystems/Spruce-Hubitat/master/drivers/Spruce%20sensor.src") {
         
         capability "Configuration"
         capability "Battery"
@@ -43,9 +56,9 @@ metadata {
         attribute "minHum", "string"
         attribute "interval", "number"
         attribute "update", "number"
-        attribute "tempOffset", "number"
         
         command "resetHumidity"
+        command "refreshAttributes"
         
         fingerprint profileId: "0104", inClusters: "0000,0001,0003,0402,0405", outClusters: "0003, 0019", manufacturer: "PLAID SYSTEMS", model: "PS-SPRZMS-01", deviceJoinName: "Spruce Sensor"
         fingerprint profileId: "0104", inClusters: "0000,0001,0003,0402,0405", outClusters: "0003, 0019", manufacturer: "PLAID SYSTEMS", model: "PS-SPRZMS-SLP1", deviceJoinName: "Spruce Sensor"
@@ -53,26 +66,69 @@ metadata {
     }
 
     preferences {
-        input "tempOffset", "number", title: "Temperature Offset", description: "Set temperature offset by this many degrees", range: "*..*", displayDuringSetup: false
-        input "interval", "number", title: "Measurement Interval", description: "Set how often you would like to check soil moisture in minutes, 1-120 minutes (default: 10 minutes)", range: "1..120", defaultValue: 10, displayDuringSetup: false
+		input "referenceTemp", "decimal", title: "<b>Reference temperature</b>", description: "Enter current reference temperature reading", displayDuringSetup: false
+        input "interval", "number", title: "<b>Measurement Interval</b>", description: "Set how often you would like to check soil moisture in minutes, 1-120 minutes (default: 10 minutes)", range: "1..120", defaultValue: 10, displayDuringSetup: false
+		input "notes", "text", title: "<b>Notes</b>", description: "Sensor location, battery change date, zone assignment, etc.", displayDuringSetup: false
+		input "debugOn", "bool", title: "<b>Enable debug logging for 1 hour</b>", defaultValue: true
+		input "infoOn", "bool", title: "<b>Enable descriptionText logging?</b>", defaultValue: true
       }    
 }
 
 def installed(){
-    
+    initialize()
 }
 
 //when device preferences are changed
-def updated(){  
-    log.debug "device updated"    
-    sendEvent(name: 'update', value: 1, descriptionText: "Settings changed and will update at next report. Measure interval set to ${interval} mins")    
-    sendEvent(name: 'interval', value: interval, descriptionText: "Interval updated")
-    sendEvent(name: 'tempOffset', value: tempOffset, descriptionText: "tempOffset updated")
+def updated(){
+	unschedule()
+	initialize()
+}
+
+def initialize() {
+	def linkText = getLinkText(device)
+	if (infoOn) log.info "${linkText} descriptionText logging enabled"
+	if (debugOn) log.info "${linkText} debug logging enabled for 1 hour"
+	log.info "${linkText} updated, settings: ${settings}"
+	
+	String descriptionText = "${linkText} settings changed, will update sensor at next report. Measurement Interval set to ${interval} minutes, update state is 1"
+	sendEvent(name: 'update', value: 1, descriptionText: descriptionText)
+	sendEvent(name: 'interval', value: interval, descriptionText: "${linkText} Measurement Interval updated")
+	if (infoOn) log.info descriptionText
+
+	// handle reference temperature / tempOffset automation
+	if (settings.referenceTemp != null) {
+		if (state.sensorTemp) {
+			state.sensorTemp = roundIt(state.sensorTemp, 2)
+			state.tempOffset = roundIt(referenceTemp - state.sensorTemp, 2)
+			settings.referenceTemp = null
+			device.clearSetting('referenceTemp')
+			if (debugOn) log.debug "sensorTemp: ${state.sensorTemp}, referenceTemp: ${referenceTemp}, offset: ${state.tempOffset}"
+			sendEvent(getTemperatureResult(state.sensorTemp))
+		} // else, preserve settings.referenceTemp, state.tempOffset will be calculate on the next temperature report
+	} else if (state.tempOffset == null) {
+		// Initialize the offset, converting from the old attribute-based approach if necessary
+		def offset = device.currentValue('tempOffset')
+		if (offset != null) {
+			log.info "${linkText} One-time tempOffset conversion completed"
+			sendEvent(name: 'tempOffset', value: null, descriptionText: "One-time tempOffset conversion completed")
+			device.clearSetting('tempOffset')
+			state.tempOffset = roundIt(offset, 2)
+			if (state.sensorTemp) sendEvent(getTemperatureResult(state.sensorTemp))
+		} else {
+			state.tempOffset = 0.0
+		}
+	}
+	
+	state.Notes = notes
+	if (debugOn) {
+		// turn off debug logging after 1 hour
+		runIn(3600, debugOff, [overwrite: true])
+	}
 }
 
 //parse events
 def parse(String description) {
-    log.debug "Parse description $description"      
+    if (debugOn) log.debug "Parse description $description"      
     
     Map map = [:]    
    
@@ -89,15 +145,15 @@ def parse(String description) {
     
     //check in configuration change    
     if (device.latestValue('update') != 0){
-        sendEvent(name: 'update', value: 0, descriptionText: "Update interval")
-        result = poll()
+		result = poll()
+		def linkText = getLinkText(device)
+        sendEvent(name: 'update', value: 0, descriptionText: "${linkText} update interval is 0")
+		if (infoOn) log.info "${linkText} update state is 0"
     }    
         
-    log.debug "parse: result: $result"
+    if (debugOn) log.debug "parse: result: $result"
     return result    
 }
-
-
 
 private Map parseCatchAllMessage(String description) {
     Map resultMap = [:]
@@ -106,13 +162,14 @@ private Map parseCatchAllMessage(String description) {
     def descMap = zigbee.parse(description)
     def descMapParse = zigbee.parseDescriptionAsMap(description)
     
-    log.debug "parseCatchAllMessage: descMapParse -> ${descMapParse}"
-    log.debug "parseCatchAllMessage: descMap -> ${descMap}"
+    if (debugOn) log.debug "parseCatchAllMessage: descMapParse -> ${descMapParse}"
+    if (debugOn) log.debug "parseCatchAllMessage: descMap -> ${descMap}"
     
     //check humidity configuration is complete
     if (descMap.command == 0x07 && descMap.clusterId == 0x0405){
-        sendEvent(name: 'update', value: 0, descriptionText: "Update interval")
-        log.debug "config complete"
+		sendEvent(name: 'update', value: 0, descriptionText: "${linkText} update state is 0")
+		if (infoOn) log.info "${linkText} update state is 0"
+        if (debugOn) log.debug "config complete"
     }
     else if (descMap.command == 0x0001){    
         def hexString = "${hex(descMap.data[5])}" + "${hex(descMap.data[4])}"
@@ -123,14 +180,14 @@ private Map parseCatchAllMessage(String description) {
             resultMap = getTemperatureResult(value)    
         }
         else if (descMap.clusterId == 0x0405){
-            def value = Math.round(new BigDecimal(intString / 100)).toString()
-            resultMap = getHumidityResult(value)
-
+            def value = roundIt(new BigDecimal(intString / 100), 0)
+            if (value != null) resultMap = getHumidityResult(value)
         }
-        else return null
+        else return [:]
     }
-    else return null 
-    
+    else return [:] 
+	
+    if (infoOn && resultMap?.descriptionText) log.info resultMap.descriptionText
     return resultMap
 }    
     
@@ -138,23 +195,29 @@ private Map parseReportAttributeMessage(String description) {
     def descMap = zigbee.parseDescriptionAsMap(description)
     def descMapParse = zigbee.parse(description)
     
-    log.debug "Desc Map: $descMap"
-    log.debug "Report Attributes"
+    if (debugOn) log.debug "Desc Map: $descMap"
+    if (debugOn) log.debug "Report Attributes"
  
     Map resultMap = [:]
     if (descMap.cluster == "0402" && descMap.attrId == "0000") {
         def value = getTemperature(descMap.value)
         resultMap = getTemperatureResult(value)    
-    }
-    if (descMap.cluster == "0405" && descMap.attrId == "0000") {
-        def intString = Integer.parseInt(descMap.value, 16)    
-        def value = Math.round(new BigDecimal(intString / 100)).toString()
-        resultMap = getHumidityResult(value)        
-    }
-    
-    if (descMap.cluster == "0001" && descMap.attrId == "0000") {        
+    } 
+	else if (descMap.cluster == "0405" && descMap.attrId == "0000") {
+        def intString = Integer.parseInt(descMap.value, 16)
+		if (debugOn) log.debug "Raw Humidity: ${intString}"
+		def value = roundIt(new BigDecimal(intString / 100.0), 0)
+		if (value != null) resultMap = getHumidityResult(value)        
+    } 
+	else if (descMap.cluster == "0001" && descMap.attrId == "0000") {        
         resultMap = getBatteryResult(descMap.value)
-    }    
+    }
+	
+	if (infoOn && resultMap?.descriptionText) {
+		if ((resultMap.name == 'battery') && (resultMap.value < 10)) {
+			log.warn resultMap.descriptionText
+		} else log.info resultMap.descriptionText
+	}
     return resultMap
 }
 
@@ -168,20 +231,24 @@ def parseDescriptionAsMap(description) {
 private Map parseCustomMessage(String description) {
     Map resultMap = [:]  
         
-    log.debug "parseCustom"
+    if (debugOn) log.debug "parseCustom"
     if (description?.startsWith('temperature: ')) {
-        def value = zigbee.parseHATemperatureValue(description, "temperature: ", getTemperatureScale())
+        def value = roundIt(zigbee.parseHATemperatureValue(description, "temperature: ", getTemperatureScale()), 2)	// maintain 2 digits of precision
+		if (debugOn) log.debug "Custom raw temperature: ${value}"
         resultMap = getTemperatureResult(value)
     }
     else if (description?.startsWith('humidity: ')) {
         def pct = (description - "humidity: " - "%").trim()
+		if (debugOn) log.debug "Custom raw humidity: ${pct}"
         if (pct.isNumber()) {           
-            def value = Math.round(new BigDecimal(pct)).toString()
+			def value = roundIt(pct, 0)
             resultMap = getHumidityResult(value)
         } else {
             log.error "invalid humidity: ${pct}"
         }    
     }
+	
+	if (infoOn && resultMap?.descriptionText) log.info resultMap.descriptionText
     return resultMap
 }
  
@@ -191,57 +258,77 @@ private Map getHumidityResult(value) {
     def minHumValue = 0
     if (device.currentValue("maxHum") != null) maxHumValue = device.currentValue("maxHum").toInteger()
     if (device.currentValue("minHum") != null) minHumValue = device.currentValue("minHum").toInteger()
-    log.debug "Humidity max: ${maxHumValue} min: ${minHumValue}"
-    def compare = value.toInteger()
+	if (debugOn) log.debug "Humidity: ${value}, max: ${maxHumValue} min: ${minHumValue}"
+    def compare = roundIt(value, 0) // value.toInteger()
     
     if (compare > maxHumValue) {
         sendEvent(name: 'maxHum', value: value, unit: '%', descriptionText: "${linkText} soil moisture high is ${value}%")
-        }
+    }
     else if (((compare < minHumValue) || (minHumValue <= 2)) && (compare != 0)) {
         sendEvent(name: 'minHum', value: value, unit: '%', descriptionText: "${linkText} soil moisture low is ${value}%")
-        }    
+    }    
     
-    return [
-        name: 'humidity',
-        value: value,
-        unit: '%',
-        descriptionText: "${linkText} soil moisture is ${value}%"
-    ]
+	if (device.currentValue('humidity') != value) {
+		// eliminate duplicate updates
+		return [
+			name: 'humidity',
+			value: value,
+			unit: '%',
+			descriptionText: "${linkText} soil moisture is ${value}%"
+		]
+	} else return [:]
 }
 
-
-
 def getTemperature(value) {
-    def celsius = (Integer.parseInt(value, 16).shortValue()/100)
-    //log.debug "Report Temp $value : $celsius C"
+    def celsius = (Integer.parseInt(value, 16).shortValue()/100.0)
+	if (debugOn) log.debug "Raw Temp ${value} : ${celsius}°C, ${celsiusToFahrenheit(celsius)}°F"
     //temp = (location.temperatureScale == "F") ? ((celsius * 1.8) + 32) : celsius
     if(location.temperatureScale == "C"){
-        return celsius
+		if (state.sensorTemp != celsius) state.sensorTemp = celsius
+		return celsius
     } else {
-        return celsiusToFahrenheit(celsius) as Integer
+		temp = roundIt(celsiusToFahrenheit(celsius), 2)	// Keep 2 digits of precision
+		if ((temp != null) && (state.sensorTemp != temp)) state.sensorTemp = temp
+		return temp
     }
 }
 
 private Map getTemperatureResult(value) {
-    log.debug "Temperature: $value"
+	if (debugOn) log.debug "getTemperatureResult(${value})"
     def linkText = getLinkText(device)
-        
-    if (tempOffset) {
-        def offset = tempOffset as int
-        def v = value as int
-        value = v + offset        
+	
+	if ((state.sensorTemp == null) || (state.sensorTemp != value)) state.sensorTemp = value
+	
+	if (settings.referenceTemp != null) {
+		state.tempOffset = roundIt((referenceTemp - value), 2)
+		settings.referenceTemp = null
+		device.clearSetting('referenceTemp')
+		if (debugOn) log.debug "sensorTemp: ${value}, referenceTemp: ${referenceTemp}, offset: ${state.tempOffset}"
+	}
+	
+	def offset = state.tempOffset
+	if (offset == null) {
+		def temp = device.currentValue('tempOffset')	// convert the old attribute to the new state variable
+		offset = (temp != null) ? temp : 0.0
+		state.tempOffset = offset
+	}
+    if (offset != 0.0) {
+    	def v = value
+    	value = roundIt((v + offset), 2)
     }
-    def descriptionText = "${linkText} is ${value}°${temperatureScale}"
-    return [
-        name: 'temperature',
-        value: value,
-        unit: temperatureScale,
-        descriptionText: descriptionText
-    ]
+	if (device.currentValue('temperature') != value) {
+		// eliminate duplicate updates
+    	return [
+        	name: 'temperature',
+        	value: value,
+        	unit: temperatureScale,
+        	descriptionText: "${linkText} temperature is ${value}°${temperatureScale}"
+    	]
+	} else return [:]
 }
 
 private Map getBatteryResult(value) {
-    log.debug 'Battery'
+    if (debugOn) log.debug 'Battery'
     def linkText = getLinkText(device)
         
     def result = [
@@ -251,38 +338,43 @@ private Map getBatteryResult(value) {
     def min = 2500   
     def percent = ((Integer.parseInt(value, 16) - min) / 5)
     percent = Math.max(0, Math.min(percent, 100.0))
-    result.value = Math.round(percent)
+	result.value = roundIt(percent, 0)
     
-    def descriptionText
-    if (percent < 10) result.descriptionText = "${linkText} battery is getting low $percent %."
-    else result.descriptionText = "${linkText} battery is ${result.value}%"
-    
-    return result
+	if (device.currentValue('battery') != result.value) {
+		if (percent < 10) result.descriptionText = "${linkText} battery is ${result.value}% - VERY LOW"		// Actually, it's probably dead at this point!
+		else if (percent < 33) result.descriptionText = "${linkText} battery is ${result.value}% - getting low"
+		else result.descriptionText = "${linkText} battery is ${result.value}% - OK"
+		return result
+	} else return [:]
 }
 
 def resetHumidity(){
     def linkText = getLinkText(device)
     def minHumValue = 0
     def maxHumValue = 0
-    sendEvent(name: 'minHum', value: minHumValue, unit: '%', descriptionText: "${linkText} min soil moisture reset to ${minHumValue}%")
-    sendEvent(name: 'maxHum', value: maxHumValue, unit: '%', descriptionText: "${linkText} max soil moisture reset to ${maxHumValue}%")
+	String descriptionText = "${linkText} min soil moisture reset to ${minHumValue}%"
+    sendEvent(name: 'minHum', value: minHumValue, unit: '%', descriptionText: descriptionText)
+	if (infoOn) log.info descriptionText
+	descriptionText = "${linkText} max soil moisture reset to ${maxHumValue}%"
+	if (infoOn) log.info descriptionText
+    sendEvent(name: 'maxHum', value: maxHumValue, unit: '%', descriptionText: descriptionText)
 }   
 
 //poll
 def poll() {
-    log.debug "poll called"
+    if (debugOn) log.debug "poll called"
     List cmds = []
     
     if (device.latestValue('update') == 2) cmds += configure()
         
     cmds += intervalUpdate()
-    log.debug "commands $cmds"
+    if (debugOn) log.debug "commands $cmds"
     return cmds?.collect { new hubitat.device.HubAction(it) }    
 }
 
 //update intervals
 def intervalUpdate(){
-    log.debug "intervalUpdate"
+    if (debugOn) log.debug "intervalUpdate"
     def minReport = 10
     def maxReport = 610
     if (interval != null) {
@@ -298,7 +390,7 @@ def intervalUpdate(){
 }
 
 def refresh() {
-    log.debug "refresh"
+    if (debugOn) log.debug "refresh"
     [
         "he rattr 0x${device.deviceNetworkId} 1 0x402 0", "delay 500",
         "he rattr 0x${device.deviceNetworkId} 1 0x405 0", "delay 500",    
@@ -306,32 +398,60 @@ def refresh() {
     ]    
 }
 
+def refreshAttributes() {
+    log.warn "Who is calling 'refreshAttributes?"
+    refresh()
+}
+
 //configure
 def configure() {
     //set minReport = measurement in minutes
     def minReport = 10
-    def maxReport = 610
-    log.debug "zigbeeId ${device.zigbeeId}"
-    if (!device.zigbeeId) sendEvent(name: 'update', value: 2, descriptionText: "Device Zigbee Id not found, remove and attempt to rejoin device")
-    else sendEvent(name: 'update',value: 0, descriptionText: "Configuration initialized")
-    
+    def maxReport = 610			// 10 hours and 10 minutes
+	if (interval != null) {
+        minReport = interval
+        maxReport = interval * 61
+    }
+	
+    if (debugOn) log.debug "zigbeeId ${device.zigbeeId}"
+	
+	def linkText = getLinkText(device)
+	String descriptionText = ""
+	if (!device.zigbeeId) { 
+		descriptionText = "${linkText} sensor's Zigbee Id not found, please remove and attempt to rejoin this sensor" 
+		log.warn descriptionText
+		sendEvent(name: 'update', value: 0, descriptionText: descriptionText)
+		//return [:]		// can we still send the config commands below if we don't know the zigbeeId???
+	}
+	else { 
+		descriptionText = "${linkText} configuration initialized" 
+    	if (infoOn) log.info descriptionText + ", update state is 0"
+		sendEvent(name: 'update', value: 0, descriptionText: descriptionText)
+	}
+	
+	// this will take about 10 seconds, all-in
     [
         "zdo bind 0x${device.deviceNetworkId} 1 1 0x402 {${device.zigbeeId}} {}", "delay 1000",
         "zdo bind 0x${device.deviceNetworkId} 1 1 0x405 {${device.zigbeeId}} {}", "delay 1000",                
         "zdo bind 0x${device.deviceNetworkId} 1 1 1 {${device.zigbeeId}} {}", "delay 1000",
         
         //temperature
-        "zcl global send-me-a-report 0x402 0x0000 0x29 1 0 {3200}",
+        "zcl global send-me-a-report 0x402 0x0000 0x29 1 0 {3200}", "delay 1000",
         "send 0x${device.deviceNetworkId} 1 1", "delay 1000",
         
         //min = soil measure interval
-        "zcl global send-me-a-report 0x405 0x0000 0x21 $minReport $maxReport {6400}",        
+        "zcl global send-me-a-report 0x405 0x0000 0x21 $minReport $maxReport {6400}", "delay 1000",        
         "send 0x${device.deviceNetworkId} 1 1", "delay 1000",       
      
         //min = battery measure interval  1 = 1 hour     
-        "zcl global send-me-a-report 1 0x0000 0x21 0x0C 0 {0500}",
+        "zcl global send-me-a-report 1 0x0000 0x21 0x0C 0 {0500}", "delay 1000",
         "send 0x${device.deviceNetworkId} 1 1", "delay 1000"
     ] + refresh()
+}
+			  
+def debugOff(){
+    log.warn "debug logging disabled..."
+    device.updateSetting("debugOn",[value:"false",type:"bool"])
 }
 
 private hex(value) {
@@ -354,4 +474,10 @@ private byte[] reverseArray(byte[] array) {
         i++;
     }
     return array
+}
+def roundIt( value, decimals=0 ) {
+	return (value == null) ? null : value.toBigDecimal().setScale(decimals, BigDecimal.ROUND_HALF_UP) 
+}
+def roundIt( BigDecimal value, decimals=0 ) {
+	return (value == null) ? null : value.setScale(decimals, BigDecimal.ROUND_HALF_UP) 
 }

--- a/drivers/Spruce sensor.src
+++ b/drivers/Spruce sensor.src
@@ -40,6 +40,7 @@
  - Added Notes preference/state variable for Location, Battery Change Date, etc.
  - Eliminate consecutive duplicate events
  - removed debug refreshAttributes()
+ - stop creating new events for duplicate values recieved within 10 seconds of each other 
 
  */
  
@@ -58,7 +59,8 @@ metadata {
         attribute "interval", "number"
         attribute "update", "number"
         
-        command "resetHumidity"
+        command "resetHumidity", []
+        command "setInterval", [[name: "Measurement Interval*", type: "NUMBER", description: "Set sensor update frequency (minutes, 1-120)"]]
         
         fingerprint profileId: "0104", inClusters: "0000,0001,0003,0402,0405", outClusters: "0003, 0019", manufacturer: "PLAID SYSTEMS", model: "PS-SPRZMS-01", deviceJoinName: "Spruce Sensor"
         fingerprint profileId: "0104", inClusters: "0000,0001,0003,0402,0405", outClusters: "0003, 0019", manufacturer: "PLAID SYSTEMS", model: "PS-SPRZMS-SLP1", deviceJoinName: "Spruce Sensor"
@@ -147,7 +149,7 @@ def parse(String description) {
     if (device.latestValue('update') != 0){
 		result = poll()
 		def linkText = getLinkText(device)
-        sendEvent(name: 'update', value: 0, descriptionText: "${linkText} update interval is 0")
+        sendEvent(name: 'update', value: 0, descriptionText: "${linkText} update state is 0")
 		if (infoOn) log.info "${linkText} update state is 0"
     }    
         
@@ -268,8 +270,12 @@ private Map getHumidityResult(value) {
         sendEvent(name: 'minHum', value: value, unit: '%', descriptionText: "${linkText} soil moisture low is ${value}%")
     }    
     
-	if (device.currentValue('humidity') != value) {
-		// eliminate duplicate updates
+    def nowDate = now()
+    def lastDate = state.lastHumDate ?: 0
+    def currentValue = device.currentValue('humidity')
+    if ((currentValue != value) || ((nowDate - lastDate) > 10000)) {
+        // eliminate duplicate updates within 10 seconds of each other
+        state.lastHumDate = nowDate
 		return [
 			name: 'humidity',
 			value: value,
@@ -282,12 +288,11 @@ private Map getHumidityResult(value) {
 def getTemperature(value) {
     def celsius = (Integer.parseInt(value, 16).shortValue()/100.0)
 	if (debugOn) log.debug "Raw Temp ${value} : ${celsius}°C, ${celsiusToFahrenheit(celsius)}°F"
-    //temp = (location.temperatureScale == "F") ? ((celsius * 1.8) + 32) : celsius
     if(location.temperatureScale == "C"){
 		if (state.sensorTemp != celsius) state.sensorTemp = celsius
 		return celsius
     } else {
-		temp = roundIt(celsiusToFahrenheit(celsius), 2)	// Keep 2 digits of precision
+		def temp = roundIt(celsiusToFahrenheit(celsius), 2)	// Keep 2 digits of precision
 		if ((temp != null) && (state.sensorTemp != temp)) state.sensorTemp = temp
 		return temp
     }
@@ -316,8 +321,13 @@ private Map getTemperatureResult(value) {
     	def v = value
     	value = roundIt((v + offset), 2)
     }
-	if (device.currentValue('temperature') != value) {
-		// eliminate duplicate updates
+    
+	def nowDate = now()
+    def lastDate = state.lastTempDate ?: 0
+    def currentValue = device.currentValue('temperature')
+    if ((currentValue != value) || ((nowDate - lastDate) > 10000)) {
+		// eliminate duplicate updates within 10 seconds of each other
+        state.lastTempDate = nowDate
     	return [
         	name: 'temperature',
         	value: value,
@@ -340,7 +350,12 @@ private Map getBatteryResult(value) {
     percent = Math.max(0, Math.min(percent, 100.0))
 	result.value = roundIt(percent, 0)
     
-	if (device.currentValue('battery') != result.value) {
+	def nowDate = now()
+    def lastDate = state.lastBattDate ?: 0
+    def currentValue = device.currentValue('battery')
+    if ((currentValue != value) || ((nowDate - lastDate) > 10000)) {
+		// eliminate duplicate updates within 10 seconds of each other
+        state.lastBattDate = nowDate
 		if (percent < 10) result.descriptionText = "${linkText} battery is ${result.value}% - VERY LOW"		// Actually, it's probably dead at this point!
 		else if (percent < 33) result.descriptionText = "${linkText} battery is ${result.value}% - getting low"
 		else result.descriptionText = "${linkText} battery is ${result.value}% - OK"
@@ -359,6 +374,15 @@ def resetHumidity(){
 	if (infoOn) log.info descriptionText
     sendEvent(name: 'maxHum', value: maxHumValue, unit: '%', descriptionText: descriptionText)
 }   
+
+def setInterval(value) {
+    if (value) {
+        def newValue = roundIt(value,0).toInteger()
+        device.updateSetting('interval', newValue)
+        settings.interval = newValue
+        updated()
+    }
+}
 
 //poll
 def poll() {

--- a/drivers/Spruce sensor.src
+++ b/drivers/Spruce sensor.src
@@ -34,11 +34,12 @@
    - debugOff after 1 hour
    - use referenceTemp to calculate tempOffset from state.sensorTemp
    - move tempOffset attribute to state.tempOffset
-   - added importUrl
+   - addeed importUrl
  - Changed all rounding to use BigDecimal.ROUND_HALF_UP
  - Globally preserve 2 decimal points of temperature precision for both Celsius and Fahrenheit (was C only)
  - Added Notes preference/state variable for Location, Battery Change Date, etc.
  - Eliminate consecutive duplicate events
+ - removed debug refreshAttributes()
 
  */
  
@@ -58,7 +59,6 @@ metadata {
         attribute "update", "number"
         
         command "resetHumidity"
-        command "refreshAttributes"
         
         fingerprint profileId: "0104", inClusters: "0000,0001,0003,0402,0405", outClusters: "0003, 0019", manufacturer: "PLAID SYSTEMS", model: "PS-SPRZMS-01", deviceJoinName: "Spruce Sensor"
         fingerprint profileId: "0104", inClusters: "0000,0001,0003,0402,0405", outClusters: "0003, 0019", manufacturer: "PLAID SYSTEMS", model: "PS-SPRZMS-SLP1", deviceJoinName: "Spruce Sensor"
@@ -396,11 +396,6 @@ def refresh() {
         "he rattr 0x${device.deviceNetworkId} 1 0x405 0", "delay 500",    
         "he rattr 0x${device.deviceNetworkId} 1 1 0"
     ]    
-}
-
-def refreshAttributes() {
-    log.warn "Who is calling 'refreshAttributes?"
-    refresh()
 }
 
 //configure

--- a/drivers/Spruce wifi master.src
+++ b/drivers/Spruce wifi master.src
@@ -17,12 +17,18 @@
  * Manual Schedule tiles
  * port to Hubitat
  *
+--------------12-2019 update by BAB--------
+ * Store & use pause device's deviceNetworkId instead of using device.label ("Spruce Pause")
+ *     (This allows users to change the name/label of the pause device without breaking things)
+ * Optimizations
  */
  
  metadata {
 	definition (name: 'Spruce wifi master', namespace: 'plaidsystems', author: 'Plaid Systems') {
 		capability "Switch"
-        capability "Switch Level"        
+        capability "Switch Level" 
+        capability "Sensor"
+        capability "Actuator"
         
         attribute "pause", "string"
         attribute "contact", "string"
@@ -37,9 +43,9 @@
 	}
     preferences {
     	input (description: "Use Level to set zone watering time. This setting does not effect scheduled water times.",
-            displayDuringSetup: false, type: "paragraph", element: "paragraph", title: "Set Level")
+            displayDuringSetup: false, type: "paragraph", element: "paragraph", title: "<b>Set Level</b>")
         input (description: "Use Update Settings to refresh the manual schedule child device list or Pause Control, update other zone settings from Spruce App.", 
-            displayDuringSetup: false, type: "paragraph", element: "paragraph", title: "Update Settings")
+            displayDuringSetup: false, type: "paragraph", element: "paragraph", title: "<b>Update Settings</b>")
     }
 }
 
@@ -48,6 +54,8 @@ def installed(){
     setPause(off)
     setRain(off)
     sendEvent(name: "switch", value: "off", isStateChange: true)    //initialize switch to off
+	sendEvent(name: "status", value: "idle", isStateChange: true)
+	sendEvent(name: "message", value: "controller initialized", isStateChange: true)
     
     updateChildren()
 }
@@ -55,6 +63,7 @@ def installed(){
 //updateSettings command
 void updateSettings(){	   
     parent.getChildren()
+	sendEvent(name: "message", value: "controller settings updated", isStateChange: true)
 }
 
 def updateChildren(){
@@ -64,8 +73,9 @@ def updateChildren(){
     try {
     	def children = getChildDevices()
         children.each{
-        log.debug it
-            if ("${it}" == "Spruce Pause") log.debug "found it"
+            log.debug it
+            //if ("${it}" == "Spruce Pause") log.debug "found it"
+            if (it.deviceNetworkId == state.pauseDeviceNetworkId) log.debug "found it"
         	deleteChildDevice(it.deviceNetworkId)
         }
     }
@@ -81,6 +91,7 @@ void createScheduleDevices(id, i, schedule, schName){
 	log.debug "master child devices"
     log.debug schedule    
     log.debug "${id}.${i}"
+    if (i == 99) state.pauseDeviceNetworkId = "${id}.99" // The pause device is always schedule #99
     
     //add children
     addChildDevice("plaidsystems", "Spruce wifi schedule", "${id}.${i}", [completedSetup: true, label: "${schName}", isComponent: true, name: "schedule${i}"])
@@ -95,35 +106,36 @@ def generateEvent(Map results) {
     if (results.value == 'on' && device.currentValue('switch') != "on"){            
         sendEvent(name: "switch", value: 'on', descriptionText: "${results.descriptionText}", displayed: true)
     }    
-    
+    switch(results.name) {
     //master switch
-    if (results.name == "switch"){
-        if (results.value == 'on') sendEvent(name: "status", value: 'schedule active', descriptionText: "${results.descriptionText}", displayed: false)
-        else if (results.value == 'off') off()
-    }
+        case "switch":
+            if (results.value == 'on') sendEvent(name: "status", value: 'schedule active', descriptionText: "${results.descriptionText}", displayed: false)
+            else if (results.value == 'off') off()
+            break
     //zone status
-    else if (results.name == 'zone'){        
-        if (results.value == 'on' && device.currentValue('switch') != 'on') sendEvent(name: "status", value: 'active', descriptionText: "${results.descriptionText}", displayed: true)
-        else if (results.value == 'off' && device.currentValue('status') == 'active') off()
-    }
+        case 'zone':       
+            if (results.value == 'on' && device.currentValue('switch') != 'on') sendEvent(name: "status", value: 'active', descriptionText: "${results.descriptionText}", displayed: true)
+            else if (results.value == 'off' && device.currentValue('status') == 'active') off()
+            break
     //zonehold status
-    else if (results.name == 'zonehold'){
-        if (results.value == 'on' && device.currentValue('switch') != 'on') sendEvent(name: "status", value: 'active', descriptionText: "${results.descriptionText}", displayed: true)
+        case 'zonehold':
+            if (results.value == 'on' && device.currentValue('switch') != 'on') sendEvent(name: "status", value: 'active', descriptionText: "${results.descriptionText}", displayed: true)
+            break
+	//rain sensor     
+        case "rainsensor":
+            sendEvent(name: "${results.name}", value: "${results.value}", descriptionText: "${results.descriptionText}", displayed: true)
+            break
+    //pause
+        case "pause":
+            sendEvent(name: "${results.name}", value: "${results.value}", descriptionText: "${results.descriptionText}", displayed: true)
+            if(results.value == 'on' && device.currentValue('status') == 'schedule active') sendEvent(name: "status", value: "pause", displayed: false)
+            else if(results.value == 'off') sendEvent(name: "status", value: "schedule active", displayed: false)
+            break
+    //contact
+        case "contact":
+            sendEvent(name: "${results.name}", value: "${results.value}", descriptionText: "${results.descriptionText}", displayed: true)
+            break
     }
-	//all events     
-    if (results.name == "rainsensor"){
-        sendEvent(name: "${results.name}", value: "${results.value}", descriptionText: "${results.descriptionText}", displayed: true)
-    }
-    if (results.name == "pause"){
-        sendEvent(name: "${results.name}", value: "${results.value}", descriptionText: "${results.descriptionText}", displayed: true)
-        if(results.value == 'on' && device.currentValue('status') == 'schedule active')sendEvent(name: "status", value: "pause", displayed: false)
-        
-        if(results.value == 'off')sendEvent(name: "status", value: "schedule active", displayed: false)
-    }    
-    if (results.name == "contact"){
-        sendEvent(name: "${results.name}", value: "${results.value}", descriptionText: "${results.descriptionText}", displayed: true)
-    }
-    
     sendEvent(name: "message", value: "${results.descriptionText}", displayed: false)
 }
 
@@ -151,12 +163,13 @@ def zoneon(dni) {
     log.debug "zoneon ${dni}"
    	def childDevice = childDevices.find{it.deviceNetworkId == dni}    
     
-    if (childDevice.currentValue('switch') != 'on'){
+    if (childDevice?.currentValue('switch') != 'on'){
     	log.debug "master zoneon ${childDevice} ${dni} on"
     	def result = [name: 'switch', value: 'on', descriptionText: "zone is on", isStateChange: true, displayed: true]    
     	childDevice.sendEvent(result)
         
-        if("${childDevice}" != "Spruce Pause") parent.scheduleOnOff(childDevice, 1)
+        //if("${childDevice}" != "Spruce Pause") parent.scheduleOnOff(childDevice, 1)
+        if(childDevice.deviceNetworkId != state.pauseDeviceNetworkId) parent.scheduleOnOff(childDevice, 1)
     	else pause()
     }
 }
@@ -164,12 +177,13 @@ def zoneon(dni) {
 def zoneoff(dni) {    
     def childDevice = childDevices.find{it.deviceNetworkId == dni}
     
-    if (childDevice.currentValue('switch') != 'off'){
+    if (childDevice?.currentValue('switch') != 'off'){
     	log.debug "master zoneoff ${childDevice} off"
     	def result = [name: 'switch', value: 'off', descriptionText: "zone is off", isStateChange: true, displayed: true]
     	childDevice.sendEvent(result)
         
-        if("${childDevice}" != "Spruce Pause") parent.scheduleOnOff(childDevice, 0)
+        //if("${childDevice}" != "Spruce Pause") parent.scheduleOnOff(childDevice, 0)
+        if(childDevice.deviceNetworkId != state.pauseDeviceNetworkId) parent.scheduleOnOff(childDevice, 0)
     	else resume()
     }
 }
@@ -202,7 +216,8 @@ void allSchedulesOff(){
 
 //pause command
 void pause(){    
-    def childDevice = childDevices.find{"${it}" == "Spruce Pause"}
+    //def childDevice = childDevices.find{"${it}" == "Spruce Pause"}
+    def childDevice = childDevices.find{it.deviceNetworkId == state.pauseDeviceNetworkId}
     
     //pause only allowed with schedules
     if(device.currentValue('status') == 'schedule active'){
@@ -214,7 +229,8 @@ void pause(){
 
 //resume command
 void resume(){
-    def childDevice = childDevices.find{"${it}" == "Spruce Pause"}
+    //def childDevice = childDevices.find{"${it}" == "Spruce Pause"}
+    def childDevice = childDevices.find{it.deviceNetworkId == state.pauseDeviceNetworkId}
     childDevice?.sendEvent(name: "switch", value: 'off', descriptionText: "Resume", isStateChange: true, displayed: true)
     
     parent.send_resume()

--- a/drivers/Spruce wifi master.src
+++ b/drivers/Spruce wifi master.src
@@ -21,6 +21,10 @@
  * Store & use pause device's deviceNetworkId instead of using device.label ("Spruce Pause")
  *     (This allows users to change the name/label of the pause device without breaking things)
  * Optimizations
+--------------06-2020 update by BAB--------
+ * No longer assumes childred have been deleted before creating new ones. Instead, will
+ * rename existing children if they already exist with different names. Also added removeScheduleDevice()
+ * so that parent can delete/remove unused Pause and/or other schedules individually
  */
  
  metadata {
@@ -69,34 +73,73 @@ void updateSettings(){
 def updateChildren(){
 	log.debug "updateChildren master"
     
-	//get and delete children avoids duplicate children    
-    try {
-    	def children = getChildDevices()
-        children.each{
-            log.debug it
-            //if ("${it}" == "Spruce Pause") log.debug "found it"
-            if (it.deviceNetworkId == state.pauseDeviceNetworkId) log.debug "found it"
-        	deleteChildDevice(it.deviceNetworkId)
-        }
-    }
-    catch (e) {
-    	log.debug "no children"
-        }
-        
+	//get and delete children avoids duplicate children - NO LONGER USED AS OF 06-2020
+	if (false) {
+		try {
+			def children = getChildDevices()
+			children.each{
+				log.debug it
+				//if ("${it}" == "Spruce Pause") log.debug "found it"
+				if (it.deviceNetworkId == state.pauseDeviceNetworkId) log.debug "found it"
+				deleteChildDevice(it.deviceNetworkId)
+			}
+		}
+		catch (e) {
+			log.debug "no children"
+			}
+	}
 	parent.child_schedules(device.deviceNetworkId)
 }
 
 //add schedule child devices
 void createScheduleDevices(id, i, schedule, schName){
-	log.debug "master child devices"
-    log.debug schedule    
-    log.debug "${id}.${i}"
-    if (i == 99) state.pauseDeviceNetworkId = "${id}.99" // The pause device is always schedule #99
+	String childDNI = "${id}.${i}"
+    if (i == 99) state.pauseDeviceNetworkId = childDNI // The pause device is always schedule #99
     
     //add children
-    addChildDevice("plaidsystems", "Spruce wifi schedule", "${id}.${i}", [completedSetup: true, label: "${schName}", isComponent: true, name: "schedule${i}"])
+	def existingChild = getChildDevice(childDNI) // getChildDevices().find(it.deviceNetworkId == childDNI)
+	String name = "schedule${i}"
+	if (!existingChild) {
+		log.info "Adding schedule ${schName} / ${schedule} (${childDNI})"
+		addChildDevice("plaidsystems", "Spruce wifi schedule", childDNI, [completedSetup: true, label: "${schName}", isComponent: true, name: name])
+	} else {
+		boolean renamed = false
+		if (existingChild.name != name) {
+			existingChild.name = name
+			renamed = true
+		}
+		if (existingChild.label != schName) {
+			existingChild.label = schName
+			renamed = true
+		}
+		if (renamed) {
+			log.info "Renamed schedule ${schName} / ${schedule} (${childDNI})"
+		} else {
+			log.info "Schedule ${schName} / ${schedule} (${childDNI}) already exists"
+		}
+			
+	}
 }
 
+//remove an unused schedule device
+void removeScheduleDevice(id, i){
+	String childDNI = "${id}.${i}"
+	def existingChild = getChildDevice(childDNI)	// getChildDevices().find(it.deviceNetworkId == childDNI)
+	if (existingChild) {
+		deleteChildDevice(childDNI)
+		if (i == 99) state.pauseDeviceNetworkId = null // The pause device is always schedule #99
+		log.debug "Removed schedule ${existingChild.label} / ${existingChild.name} (${childDNI})"
+	} else {
+		log.debug "Schedule ${childDNI} does not exist (removing)"
+	}
+}
+//removes ALL schedule devices
+void removeScheduleDevices() {
+	childDevices?.each {
+		log.debug "Removed schedule ${it.label} / ${it.name} (${it.deviceNetworkId})"
+		deleteChildDevice(it.deviceNetworkId)
+	}
+}
 
 def generateEvent(Map results) {    
     //log.debug "master status: ${device.status}"
@@ -161,7 +204,7 @@ def setPause(value) {
 //************* Commands to/from pause and schedule children *******************
 def zoneon(dni) {	
     log.debug "zoneon ${dni}"
-   	def childDevice = childDevices.find{it.deviceNetworkId == dni}    
+   	def childDevice = getChildDevice(dni) // childDevices.find{it.deviceNetworkId == dni}    
     
     if (childDevice?.currentValue('switch') != 'on'){
     	log.debug "master zoneon ${childDevice} ${dni} on"
@@ -175,7 +218,8 @@ def zoneon(dni) {
 }
 
 def zoneoff(dni) {    
-    def childDevice = childDevices.find{it.deviceNetworkId == dni}
+	log.debug "zoneoff ${dni}"
+    def childDevice = getChildDevice(dni)	// childDevices.find{it.deviceNetworkId == dni}
     
     if (childDevice?.currentValue('switch') != 'off'){
     	log.debug "master zoneoff ${childDevice} off"
@@ -201,7 +245,7 @@ void on(){
 void off(){
     log.debug "---------------switch off"
     sendEvent(name: "switch", value: 'off', descriptionText: "${device.label} is off", displayed: false)
-    sendEvent(name: "status", value: 'Idle', descriptionText: "${device.label} is off", displayed: true)
+    sendEvent(name: "status", value: 'idle', descriptionText: "${device.label} is off", displayed: true)
     allSchedulesOff()
     parent.send_stop()
 }
@@ -217,10 +261,10 @@ void allSchedulesOff(){
 //pause command
 void pause(){    
     //def childDevice = childDevices.find{"${it}" == "Spruce Pause"}
-    def childDevice = childDevices.find{it.deviceNetworkId == state.pauseDeviceNetworkId}
+    def childDevice = state.pauseDeviceNetworkId ? getChildDevice(state.pauseDeviceNetworkId) : null // childDevices.find{it.deviceNetworkId == state.pauseDeviceNetworkId}
     
     //pause only allowed with schedules
-    if(device.currentValue('status') == 'schedule active'){
+    if(device.currentValue('status').contains('active')){
         childDevice?.sendEvent(name: "switch", value: 'on', descriptionText: "Pause", isStateChange: true, displayed: true)    
         parent.send_pause()
     }
@@ -230,7 +274,7 @@ void pause(){
 //resume command
 void resume(){
     //def childDevice = childDevices.find{"${it}" == "Spruce Pause"}
-    def childDevice = childDevices.find{it.deviceNetworkId == state.pauseDeviceNetworkId}
+    def childDevice = state.pauseDeviceNetworkId ? getChildDevice(state.pauseDeviceNetworkId) : null // childDevices.find{it.deviceNetworkId == state.pauseDeviceNetworkId}
     childDevice?.sendEvent(name: "switch", value: 'off', descriptionText: "Resume", isStateChange: true, displayed: true)
     
     parent.send_resume()


### PR DESCRIPTION
Nate (et al) -

Here are some proposed updates for the base Hubitat code. Most changes are noted within each module, but the overview is this:
1) Spruce Control now creates all devices with more descriptive device Labels - e.g. "Spruce Lawn Controller" instead of just "Lawn"; "Spruce Lawn Controller Zone 01" instead of "Zone 01", etc.
  - this includes the "Spruce Pause" child device(s) which are now labelled "Spruce Lawn Controller Pause". This change necessitated changing the Spruce wifi master to use the actual deviceNetworkId of the Pause device instead of its name/label when referencing the device. The deviceNetworkId is stored as a state variable when the Pause device is created.
2. For the sensors, the code has been refactored for the Hubitat environment in 3 ways:
  - Instead of entering a temperature offset, ALL Hubitat temperature devices use the "Enter current reference temperature reading" approach, and calculate the offset automatically from this data point;
  - Added conditionals for log.debug and log.info logging (logging is a large overhead on Hubitat). Both are enabled by default, but in keeping with Hubitat standards, the debug logging is disabled after 1 hour (usually it is only 30 minutes, but these devices are really lazy 😄)
  - added the `importUrl definition in the device metadata section
3. Various optimizations, like increased decimal precision and ROUND_HALF_UP instead of Math.round

I will likely have more updates to offer over time, as I am working towards a version that natively supports multiple controllers instead of the current limitation of only 1 controller per Hub. Users of multiple Hubitat Hubs linked via HubConnect can get around the limitations fairly easily, and I will be releasing Custom Drivers that help make that a reality for people. But ultimately, the system should readily support multiple controllers, although it will take a bit more work to make that a reality.